### PR TITLE
Add archived toggle, hero image upload, tenant share, and Academies

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -37,6 +37,8 @@ const Support = lazy(() => import("@/pages/Support"));
 const Courses = lazy(() => import("@/pages/Courses"));
 const CourseDetail = lazy(() => import("@/pages/CourseDetail"));
 const MyCourses = lazy(() => import("@/pages/MyCourses"));
+const Academies = lazy(() => import("@/pages/Academies"));
+const AcademyDetail = lazy(() => import("@/pages/AcademyDetail"));
 
 function RouteFallback() {
   return (
@@ -79,6 +81,8 @@ function Router() {
             <Route path="/courses" component={Courses} />
             <ProtectedRoute path="/my-courses" component={MyCourses} />
             <Route path="/courses/:slug" component={CourseDetail} />
+            <Route path="/academies" component={Academies} />
+            <Route path="/academies/:slug" component={AcademyDetail} />
             <Route path="/assessment/:assessmentId" component={Assessment} />
             <Route path="/results/:assessmentId" component={Results} />
             <ProtectedRoute path="/me" component={Profile} />

--- a/client/src/components/admin/AcademyManagement.tsx
+++ b/client/src/components/admin/AcademyManagement.tsx
@@ -281,6 +281,7 @@ function AcademyBuilder({ academyId, onClose }: { academyId: string; onClose: ()
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}`] });
       queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true&includeArchived=true"] });
     },
   });
 
@@ -290,6 +291,7 @@ function AcademyBuilder({ academyId, onClose }: { academyId: string; onClose: ()
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}`] });
       queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true&includeArchived=true"] });
       toast({ title: "Image uploaded" });
     },
     onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
@@ -472,6 +474,7 @@ function AcademyOverview({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [`/api/academies/${academy.id}`] });
       queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true&includeArchived=true"] });
       toast({ title: "Image removed" });
     },
   });

--- a/client/src/components/admin/AcademyManagement.tsx
+++ b/client/src/components/admin/AcademyManagement.tsx
@@ -1,0 +1,833 @@
+import { useState } from "react";
+import { useQuery, useMutation } from "@tanstack/react-query";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/use-auth";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { ObjectUploader } from "@/components/ObjectUploader";
+import {
+  Plus, Edit, Trash, ChevronLeft, Save, Loader2, Upload, X, ChevronDown, Share2,
+  ArrowUp, ArrowDown, BookOpen, ExternalLink, GraduationCap,
+} from "lucide-react";
+import type {
+  Academy, AcademyItem, AcademyExternalProvider, Course,
+} from "@shared/schema";
+
+interface AcademyListItem extends Academy {
+  itemCount: number;
+}
+
+interface AcademyItemWithCourse extends AcademyItem {
+  course?: Pick<Course, "id" | "slug" | "title" | "summary" | "imageUrl" | "estimatedMinutes" | "status" | "visibility"> | null;
+}
+
+interface AcademyFull extends Academy {
+  items: AcademyItemWithCourse[];
+}
+
+interface TenantShareRow {
+  id: string;
+  tenantId: string;
+  tenantName: string;
+  createdAt: string;
+}
+
+interface TenantOption { id: string; name: string }
+
+const PROVIDER_LABELS: Record<AcademyExternalProvider, string> = {
+  linkedin_learning: "LinkedIn Learning",
+  coursera: "Coursera",
+  pluralsight: "Pluralsight",
+  youtube: "YouTube",
+  udemy: "Udemy",
+  edx: "edX",
+  other: "Other",
+};
+
+const slugify = (s: string) =>
+  s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "").slice(0, 100);
+
+export function AcademyManagement() {
+  const { toast } = useToast();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
+
+  const listUrl = showArchived
+    ? "/api/academies?manageable=true&includeArchived=true"
+    : "/api/academies?manageable=true";
+  const { data: academies, isLoading } = useQuery<AcademyListItem[]>({
+    queryKey: [listUrl],
+  });
+
+  const archiveMutation = useMutation({
+    mutationFn: async (id: string) => apiRequest(`/api/academies/${id}`, "DELETE"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true&includeArchived=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies"] });
+      toast({ title: "Academy archived" });
+    },
+  });
+
+  if (editingId) {
+    return <AcademyBuilder academyId={editingId} onClose={() => setEditingId(null)} />;
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-2xl font-bold" data-testid="text-academies-admin-heading">Academies</h2>
+          <p className="text-muted-foreground text-sm">
+            Build sequenced learning paths from Orion courses and external sources (LinkedIn Learning, Coursera, etc.).
+          </p>
+        </div>
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <Switch
+              id="toggle-show-archived-academies"
+              checked={showArchived}
+              onCheckedChange={setShowArchived}
+              data-testid="switch-show-archived-academies"
+            />
+            <Label htmlFor="toggle-show-archived-academies" className="cursor-pointer">Show archived</Label>
+          </div>
+          <Button onClick={() => setCreating(true)} data-testid="button-new-academy">
+            <Plus className="h-4 w-4 mr-1" /> New academy
+          </Button>
+        </div>
+      </div>
+
+      {isLoading && <Skeleton className="h-32 w-full" />}
+
+      {!isLoading && (!academies || academies.length === 0) && (
+        <Card>
+          <CardContent className="pt-6 text-muted-foreground" data-testid="text-no-academies">
+            No academies yet. Create one to start sequencing courses.
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && academies && academies.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          {academies.map(a => (
+            <Card
+              key={a.id}
+              className={`hover-elevate ${a.status === "archived" ? "opacity-60" : ""}`}
+              data-testid={`card-admin-academy-${a.id}`}
+            >
+              {a.imageUrl && (
+                <div className="aspect-video w-full overflow-hidden rounded-t-md">
+                  <img src={a.imageUrl} alt={a.title} className="w-full h-full object-cover" />
+                </div>
+              )}
+              <CardHeader>
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex-1 min-w-0">
+                    <CardTitle className="text-base truncate" data-testid={`text-admin-academy-title-${a.id}`}>{a.title}</CardTitle>
+                    <p className="text-xs text-muted-foreground">/{a.slug}</p>
+                  </div>
+                  <div className="flex gap-1 flex-wrap">
+                    <Badge variant={a.status === "published" ? "default" : a.status === "archived" ? "destructive" : "secondary"}>
+                      {a.status}
+                    </Badge>
+                    <Badge variant="outline">{a.visibility}</Badge>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="flex items-center gap-3 text-sm text-muted-foreground mb-3">
+                  <span>{a.itemCount} item{a.itemCount === 1 ? "" : "s"}</span>
+                </div>
+                <div className="flex gap-2">
+                  <Button size="sm" variant="outline" onClick={() => setEditingId(a.id)} data-testid={`button-edit-academy-${a.id}`}>
+                    <Edit className="h-3 w-3 mr-1" /> Edit
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => {
+                      if (confirm(`Archive "${a.title}"?`)) archiveMutation.mutate(a.id);
+                    }}
+                    data-testid={`button-archive-academy-${a.id}`}
+                  >
+                    <Trash className="h-3 w-3" />
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {creating && (
+        <CreateAcademyDialog
+          onClose={() => setCreating(false)}
+          onCreated={(id) => { setCreating(false); setEditingId(id); }}
+        />
+      )}
+    </div>
+  );
+}
+
+function CreateAcademyDialog({ onClose, onCreated }: { onClose: () => void; onCreated: (id: string) => void }) {
+  const { toast } = useToast();
+  const [title, setTitle] = useState("");
+  const [slug, setSlug] = useState("");
+  const [summary, setSummary] = useState("");
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const finalSlug = slug || slugify(title);
+      return await apiRequest("/api/academies", "POST", {
+        title, slug: finalSlug, summary, description: summary,
+      });
+    },
+    onSuccess: (academy: Academy) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true&includeArchived=true"] });
+      toast({ title: "Academy created" });
+      onCreated(academy.id);
+    },
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New academy</DialogTitle>
+          <DialogDescription>Start with a title — you can add courses and external links next.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div>
+            <Label htmlFor="academy-title">Title</Label>
+            <Input
+              id="academy-title"
+              value={title}
+              onChange={e => { setTitle(e.target.value); if (!slug) setSlug(slugify(e.target.value)); }}
+              data-testid="input-new-academy-title"
+            />
+          </div>
+          <div>
+            <Label htmlFor="academy-slug">Slug</Label>
+            <Input id="academy-slug" value={slug} onChange={e => setSlug(slugify(e.target.value))} data-testid="input-new-academy-slug" />
+            <p className="text-xs text-muted-foreground mt-1">URL: /academies/{slug || "your-slug"}</p>
+          </div>
+          <div>
+            <Label htmlFor="academy-summary">Summary</Label>
+            <Textarea id="academy-summary" value={summary} onChange={e => setSummary(e.target.value)} data-testid="input-new-academy-summary" />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button
+            onClick={() => createMutation.mutate()}
+            disabled={!title || !slug || createMutation.isPending}
+            data-testid="button-create-academy-submit"
+          >
+            {createMutation.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Create
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AcademyBuilder({ academyId, onClose }: { academyId: string; onClose: () => void }) {
+  const { toast } = useToast();
+  const { user } = useAuth();
+  const isGlobalAdmin = user?.role === "global_admin";
+  const { data: academy, isLoading } = useQuery<AcademyFull>({
+    queryKey: [`/api/academies/${academyId}`],
+  });
+  const [tab, setTab] = useState<"overview" | "items">("overview");
+  const [addingItem, setAddingItem] = useState(false);
+  const [showTenantShare, setShowTenantShare] = useState(false);
+
+  const updateMut = useMutation({
+    mutationFn: async (patch: Partial<Academy>) => apiRequest(`/api/academies/${academyId}`, "PUT", patch),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}`] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true&includeArchived=true"] });
+      toast({ title: "Saved" });
+    },
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  const reorderMut = useMutation({
+    mutationFn: async (orderedIds: string[]) =>
+      apiRequest(`/api/academies/${academyId}/items/reorder`, "PUT", { orderedIds }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}`] });
+    },
+  });
+
+  const deleteItemMut = useMutation({
+    mutationFn: async (id: string) => apiRequest(`/api/academy-items/${id}`, "DELETE"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}`] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+    },
+  });
+
+  const uploadImage = useMutation({
+    mutationFn: async (imageUrl: string) =>
+      apiRequest(`/api/academies/${academyId}/image`, "PUT", { imageUrl }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}`] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      toast({ title: "Image uploaded" });
+    },
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  const handleGetUploadParameters = async () => {
+    const res = await fetch("/api/objects/upload", { method: "POST", credentials: "include" });
+    const data = await res.json();
+    return { method: "PUT" as const, url: data.uploadURL };
+  };
+
+  if (isLoading || !academy) {
+    return (
+      <div className="space-y-3">
+        <Button variant="ghost" size="sm" onClick={onClose}><ChevronLeft className="h-4 w-4 mr-1" /> Back</Button>
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  const moveItem = (itemId: string, direction: -1 | 1) => {
+    const ids = academy.items.map(i => i.id);
+    const idx = ids.indexOf(itemId);
+    const target = idx + direction;
+    if (idx < 0 || target < 0 || target >= ids.length) return;
+    [ids[idx], ids[target]] = [ids[target], ids[idx]];
+    reorderMut.mutate(ids);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <Button variant="ghost" size="sm" onClick={onClose} data-testid="button-back-to-academies-list">
+          <ChevronLeft className="h-4 w-4 mr-1" /> All academies
+        </Button>
+        <h2 className="text-xl font-bold flex-1">{academy.title}</h2>
+        <Badge>{academy.status}</Badge>
+      </div>
+
+      <div className="flex gap-2 border-b">
+        {(["overview", "items"] as const).map(t => (
+          <Button
+            key={t}
+            variant="ghost"
+            size="sm"
+            className={tab === t ? "border-b-2 border-primary rounded-none" : ""}
+            onClick={() => setTab(t)}
+            data-testid={`tab-academy-${t}`}
+          >
+            {t.charAt(0).toUpperCase() + t.slice(1)}
+          </Button>
+        ))}
+      </div>
+
+      {tab === "overview" && (
+        <AcademyOverview
+          academy={academy}
+          isGlobalAdmin={isGlobalAdmin}
+          saving={updateMut.isPending}
+          onSave={(patch) => updateMut.mutate(patch)}
+          onUploadImage={uploadImage.mutate}
+          onGetUploadParameters={handleGetUploadParameters}
+          onOpenTenantShare={() => setShowTenantShare(true)}
+        />
+      )}
+
+      {tab === "items" && (
+        <div className="space-y-3">
+          <Card>
+            <CardContent className="pt-6">
+              <Button onClick={() => setAddingItem(true)} data-testid="button-add-academy-item">
+                <Plus className="h-4 w-4 mr-1" /> Add item
+              </Button>
+            </CardContent>
+          </Card>
+          {academy.items.length === 0 && (
+            <Card><CardContent className="pt-6 text-muted-foreground">No items yet — add an Orion course or an external link.</CardContent></Card>
+          )}
+          {academy.items.map((item, idx) => (
+            <Card key={item.id} data-testid={`row-academy-item-${item.id}`}>
+              <CardContent className="pt-4">
+                <div className="flex items-center justify-between gap-3 flex-wrap">
+                  <div className="flex items-center gap-3 flex-1 min-w-0">
+                    <div className="text-muted-foreground font-mono text-sm w-8 text-right">{idx + 1}.</div>
+                    {item.itemType === "course" ? (
+                      <BookOpen className="h-4 w-4 text-muted-foreground shrink-0" />
+                    ) : (
+                      <ExternalLink className="h-4 w-4 text-muted-foreground shrink-0" />
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <div className="font-medium truncate">
+                        {item.itemType === "course"
+                          ? (item.course?.title ?? <span className="text-destructive">[course missing]</span>)
+                          : item.externalTitle}
+                      </div>
+                      <div className="text-xs text-muted-foreground truncate">
+                        {item.itemType === "course"
+                          ? `Orion course / ${item.course?.slug ?? "?"}`
+                          : `${PROVIDER_LABELS[item.externalProvider as AcademyExternalProvider] ?? "External"} — ${item.externalUrl}`}
+                      </div>
+                    </div>
+                    {item.required && <Badge variant="outline">required</Badge>}
+                  </div>
+                  <div className="flex gap-1">
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => moveItem(item.id, -1)}
+                      disabled={idx === 0 || reorderMut.isPending}
+                      data-testid={`button-move-up-${item.id}`}
+                    >
+                      <ArrowUp className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => moveItem(item.id, 1)}
+                      disabled={idx === academy.items.length - 1 || reorderMut.isPending}
+                      data-testid={`button-move-down-${item.id}`}
+                    >
+                      <ArrowDown className="h-3 w-3" />
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        if (confirm(`Remove this item from the academy?`)) deleteItemMut.mutate(item.id);
+                      }}
+                      data-testid={`button-delete-academy-item-${item.id}`}
+                    >
+                      <Trash className="h-3 w-3" />
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {addingItem && (
+        <AddAcademyItemDialog
+          academyId={academyId}
+          existingCount={academy.items.length}
+          onClose={() => setAddingItem(false)}
+        />
+      )}
+
+      {showTenantShare && (
+        <AcademyTenantShareDialog
+          academyId={academyId}
+          onClose={() => setShowTenantShare(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function AcademyOverview({
+  academy, isGlobalAdmin, saving, onSave, onUploadImage, onGetUploadParameters, onOpenTenantShare,
+}: {
+  academy: AcademyFull;
+  isGlobalAdmin: boolean;
+  saving: boolean;
+  onSave: (patch: any) => void;
+  onUploadImage: (url: string) => void;
+  onGetUploadParameters: () => Promise<{ method: "PUT"; url: string }>;
+  onOpenTenantShare: () => void;
+}) {
+  const { toast } = useToast();
+  const [title, setTitle] = useState(academy.title);
+  const [summary, setSummary] = useState(academy.summary || "");
+  const [description, setDescription] = useState(academy.description);
+  const [estimatedMinutes, setEstimatedMinutes] = useState(academy.estimatedMinutes?.toString() || "");
+  const [status, setStatus] = useState(academy.status);
+  const [visibility, setVisibility] = useState(academy.visibility);
+
+  const removeImage = useMutation({
+    mutationFn: async () => apiRequest(`/api/academies/${academy.id}`, "PUT", { imageUrl: null }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/academies/${academy.id}`] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      toast({ title: "Image removed" });
+    },
+  });
+
+  const handleUploadComplete = (result: any) => {
+    const url = result?.successful?.[0]?.uploadURL;
+    if (url) onUploadImage(url);
+  };
+
+  const handleSave = () => {
+    onSave({
+      title, summary: summary || null, description,
+      estimatedMinutes: estimatedMinutes ? parseInt(estimatedMinutes, 10) : null,
+      status, visibility,
+    });
+  };
+
+  return (
+    <Card>
+      <CardContent className="pt-6 space-y-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+          <div>
+            <Label htmlFor="ac-title">Title</Label>
+            <Input id="ac-title" value={title} onChange={e => setTitle(e.target.value)} data-testid="input-academy-title" />
+          </div>
+          <div>
+            <Label htmlFor="ac-min">Estimated minutes</Label>
+            <Input id="ac-min" type="number" value={estimatedMinutes} onChange={e => setEstimatedMinutes(e.target.value)} data-testid="input-academy-minutes" />
+          </div>
+          <div>
+            <Label htmlFor="ac-status">Status</Label>
+            <Select value={status} onValueChange={v => setStatus(v as any)}>
+              <SelectTrigger id="ac-status" data-testid="select-academy-status"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="draft">Draft</SelectItem>
+                <SelectItem value="published">Published</SelectItem>
+                <SelectItem value="archived">Archived</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div>
+            <Label htmlFor="ac-vis">Visibility</Label>
+            <Select value={visibility} onValueChange={v => setVisibility(v as any)} disabled={!isGlobalAdmin}>
+              <SelectTrigger id="ac-vis" data-testid="select-academy-visibility"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="public">Public</SelectItem>
+                <SelectItem value="private">Private (tenant-only)</SelectItem>
+              </SelectContent>
+            </Select>
+            {!isGlobalAdmin && (
+              <p className="text-xs text-muted-foreground mt-1">Only global admins can change visibility.</p>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <Label>Hero image</Label>
+          <p className="text-sm text-muted-foreground mb-2">Upload an image for this academy (under 10MB).</p>
+          {academy.imageUrl ? (
+            <div className="space-y-2">
+              <div className="relative rounded-lg overflow-hidden border border-border max-w-md">
+                <img src={academy.imageUrl} alt={academy.title} className="w-full h-48 object-cover" data-testid="img-academy-hero" />
+              </div>
+              <div className="flex gap-2">
+                <ObjectUploader
+                  maxNumberOfFiles={1}
+                  maxFileSize={10485760}
+                  allowedFileTypes={["image/jpeg", "image/png", "image/webp"]}
+                  onGetUploadParameters={onGetUploadParameters}
+                  onComplete={handleUploadComplete}
+                  buttonVariant="outline"
+                >
+                  <Upload className="h-4 w-4 mr-2" /> Replace image
+                </ObjectUploader>
+                <Button
+                  variant="outline"
+                  onClick={() => removeImage.mutate()}
+                  disabled={removeImage.isPending}
+                  data-testid="button-remove-academy-image"
+                >
+                  <X className="h-4 w-4 mr-2" />
+                  {removeImage.isPending ? "Removing..." : "Remove"}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <ObjectUploader
+              maxNumberOfFiles={1}
+              maxFileSize={10485760}
+              allowedFileTypes={["image/jpeg", "image/png", "image/webp"]}
+              onGetUploadParameters={onGetUploadParameters}
+              onComplete={handleUploadComplete}
+            >
+              <Upload className="h-4 w-4 mr-2" /> Upload image
+            </ObjectUploader>
+          )}
+        </div>
+
+        <div>
+          <Label htmlFor="ac-summary">Summary (catalog blurb)</Label>
+          <Textarea id="ac-summary" value={summary} onChange={e => setSummary(e.target.value)} data-testid="input-academy-summary" />
+        </div>
+        <div>
+          <Label htmlFor="ac-description">Description</Label>
+          <Textarea id="ac-description" value={description} rows={6} onChange={e => setDescription(e.target.value)} data-testid="input-academy-description" />
+        </div>
+
+        {visibility === "private" && (
+          <div className="rounded-md border p-3 bg-muted/30">
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <p className="font-medium">Tenant access</p>
+                <p className="text-sm text-muted-foreground">
+                  Share this private academy with selected customer tenants beyond its owner.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                onClick={onOpenTenantShare}
+                disabled={!isGlobalAdmin}
+                data-testid="button-manage-academy-tenants"
+              >
+                <Share2 className="h-4 w-4 mr-1" /> Manage tenants
+              </Button>
+            </div>
+            {!isGlobalAdmin && (
+              <p className="text-xs text-muted-foreground mt-2">Only global admins can attach academies to other tenants.</p>
+            )}
+          </div>
+        )}
+
+        <Button onClick={handleSave} disabled={saving} data-testid="button-save-academy-overview">
+          {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+          <Save className="h-4 w-4 mr-1" /> Save
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AddAcademyItemDialog({
+  academyId, existingCount, onClose,
+}: {
+  academyId: string;
+  existingCount: number;
+  onClose: () => void;
+}) {
+  const { toast } = useToast();
+  const [itemType, setItemType] = useState<"course" | "external">("course");
+  const [courseId, setCourseId] = useState("");
+  const [externalProvider, setExternalProvider] = useState<AcademyExternalProvider>("linkedin_learning");
+  const [externalTitle, setExternalTitle] = useState("");
+  const [externalUrl, setExternalUrl] = useState("");
+  const [externalDuration, setExternalDuration] = useState("");
+  const [externalDescription, setExternalDescription] = useState("");
+  const [required, setRequired] = useState(true);
+
+  const { data: courses } = useQuery<{ id: string; title: string; slug: string; status: string }[]>({
+    queryKey: ["/api/courses?manageable=true"],
+  });
+
+  const createMut = useMutation({
+    mutationFn: async () => {
+      const body: any = {
+        itemType,
+        order: existingCount,
+        required,
+      };
+      if (itemType === "course") {
+        body.courseId = courseId;
+      } else {
+        body.externalProvider = externalProvider;
+        body.externalTitle = externalTitle;
+        body.externalUrl = externalUrl;
+        body.externalDescription = externalDescription || null;
+        body.externalDurationMinutes = externalDuration ? parseInt(externalDuration, 10) : null;
+      }
+      return apiRequest(`/api/academies/${academyId}/items`, "POST", body);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}`] });
+      queryClient.invalidateQueries({ queryKey: ["/api/academies?manageable=true"] });
+      toast({ title: "Item added" });
+      onClose();
+    },
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  const canSubmit = itemType === "course"
+    ? !!courseId
+    : !!externalTitle && !!externalUrl;
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Add academy item</DialogTitle>
+          <DialogDescription>Add an Orion course or an external link to this learning sequence.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div>
+            <Label htmlFor="item-type">Type</Label>
+            <Select value={itemType} onValueChange={v => setItemType(v as any)}>
+              <SelectTrigger id="item-type" data-testid="select-academy-item-type"><SelectValue /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="course">Orion course</SelectItem>
+                <SelectItem value="external">External (LinkedIn Learning, etc.)</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          {itemType === "course" && (
+            <div>
+              <Label htmlFor="item-course">Course</Label>
+              <Select value={courseId} onValueChange={setCourseId}>
+                <SelectTrigger id="item-course" data-testid="select-academy-item-course">
+                  <SelectValue placeholder="Pick a course" />
+                </SelectTrigger>
+                <SelectContent>
+                  {(courses ?? [])
+                    .filter(c => c.status !== "archived")
+                    .map(c => (
+                      <SelectItem key={c.id} value={c.id}>{c.title}</SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {itemType === "external" && (
+            <>
+              <div>
+                <Label htmlFor="item-provider">Provider</Label>
+                <Select value={externalProvider} onValueChange={v => setExternalProvider(v as AcademyExternalProvider)}>
+                  <SelectTrigger id="item-provider" data-testid="select-academy-item-provider"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(PROVIDER_LABELS).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Label htmlFor="item-ext-title">Title</Label>
+                <Input id="item-ext-title" value={externalTitle} onChange={e => setExternalTitle(e.target.value)} data-testid="input-academy-item-ext-title" />
+              </div>
+              <div>
+                <Label htmlFor="item-ext-url">URL</Label>
+                <Input id="item-ext-url" type="url" value={externalUrl} onChange={e => setExternalUrl(e.target.value)} data-testid="input-academy-item-ext-url" />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <Label htmlFor="item-ext-min">Duration (minutes)</Label>
+                  <Input id="item-ext-min" type="number" value={externalDuration} onChange={e => setExternalDuration(e.target.value)} />
+                </div>
+              </div>
+              <div>
+                <Label htmlFor="item-ext-desc">Description</Label>
+                <Textarea id="item-ext-desc" value={externalDescription} onChange={e => setExternalDescription(e.target.value)} />
+              </div>
+            </>
+          )}
+
+          <div className="flex items-center gap-2">
+            <Switch id="item-required" checked={required} onCheckedChange={setRequired} data-testid="switch-academy-item-required" />
+            <Label htmlFor="item-required">Required</Label>
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button
+            onClick={() => createMut.mutate()}
+            disabled={!canSubmit || createMut.isPending}
+            data-testid="button-create-academy-item-submit"
+          >
+            {createMut.isPending && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Add
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function AcademyTenantShareDialog({ academyId, onClose }: { academyId: string; onClose: () => void }) {
+  const { toast } = useToast();
+  const { data: assigned, isLoading } = useQuery<TenantShareRow[]>({
+    queryKey: [`/api/academies/${academyId}/tenants`],
+  });
+  const { data: tenants } = useQuery<TenantOption[]>({
+    queryKey: ["/api/model-tenants"],
+  });
+
+  const addMut = useMutation({
+    mutationFn: async (tenantId: string) =>
+      apiRequest(`/api/academies/${academyId}/tenants`, "POST", { tenantId }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}/tenants`] }),
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+  const removeMut = useMutation({
+    mutationFn: async (tenantId: string) =>
+      apiRequest(`/api/academies/${academyId}/tenants/${tenantId}`, "DELETE"),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: [`/api/academies/${academyId}/tenants`] }),
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  const assignedIds = new Set((assigned ?? []).map(a => a.tenantId));
+  const sortedTenants = (tenants ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Academy tenant access</DialogTitle>
+          <DialogDescription>Pick which tenants can access this private academy.</DialogDescription>
+        </DialogHeader>
+        {isLoading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="w-full justify-between" data-testid="select-academy-tenants">
+                {assignedIds.size === 0
+                  ? "Select tenants"
+                  : `${assignedIds.size} tenant${assignedIds.size > 1 ? "s" : ""} selected`}
+                <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-[440px]">
+              {sortedTenants.length === 0 ? (
+                <div className="p-2 text-sm text-muted-foreground">No tenants available</div>
+              ) : (
+                sortedTenants.map(t => (
+                  <DropdownMenuCheckboxItem
+                    key={t.id}
+                    checked={assignedIds.has(t.id)}
+                    onCheckedChange={(checked) => {
+                      if (checked) addMut.mutate(t.id);
+                      else removeMut.mutate(t.id);
+                    }}
+                    data-testid={`checkbox-academy-tenant-${t.id}`}
+                  >
+                    {t.name}
+                  </DropdownMenuCheckboxItem>
+                ))
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        <DialogFooter>
+          <Button onClick={onClose}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// Re-export the icon used in the sidebar
+export { GraduationCap as AcademyIcon };

--- a/client/src/components/admin/CourseManagement.tsx
+++ b/client/src/components/admin/CourseManagement.tsx
@@ -12,8 +12,23 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
-import { Plus, Edit, Trash, Users, ChevronLeft, FileText, Save, Loader2, Upload, Download } from "lucide-react";
+import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
+import { Plus, Edit, Trash, Users, ChevronLeft, FileText, Save, Loader2, Upload, Download, X, ChevronDown, Share2 } from "lucide-react";
+import { ObjectUploader } from "@/components/ObjectUploader";
+import { useAuth } from "@/hooks/use-auth";
 import type { Course, CourseModule, Lesson, CourseTag, LessonType, CourseEnrollment } from "@shared/schema";
+
+interface TenantShareRow {
+  id: string;
+  tenantId: string;
+  tenantName: string;
+  createdAt: string;
+}
+
+interface TenantOption {
+  id: string;
+  name: string;
+}
 
 interface CourseListItem extends Course {
   moduleCount: number;
@@ -42,17 +57,23 @@ export function CourseManagement() {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
   const [importing, setImporting] = useState(false);
+  const [showArchived, setShowArchived] = useState(false);
   const importFileRef = useRef<HTMLInputElement>(null);
 
+  const listUrl = showArchived
+    ? "/api/courses?manageable=true&includeArchived=true"
+    : "/api/courses?manageable=true";
   const { data: courses, isLoading } = useQuery<CourseListItem[]>({
-    queryKey: ["/api/courses?manageable=true"],
+    queryKey: [listUrl],
   });
 
   const archiveMutation = useMutation({
     mutationFn: async (id: string) => apiRequest(`/api/courses/${id}`, "DELETE"),
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/courses?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/courses?manageable=true&includeArchived=true"] });
       queryClient.invalidateQueries({ queryKey: ["/api/courses"] });
-      toast({ title: "Course archived", description: "Hidden from the catalog. Set status back to 'draft' or 'published' to restore." });
+      toast({ title: "Course archived", description: "Hidden from the catalog. Toggle 'Show archived' to see it, or set status back to 'draft' or 'published' to restore." });
     },
   });
 
@@ -60,6 +81,8 @@ export function CourseManagement() {
     mutationFn: async (doc: unknown) =>
       apiRequest("/api/courses/import/json", "POST", doc),
     onSuccess: (result: any) => {
+      queryClient.invalidateQueries({ queryKey: ["/api/courses?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/courses?manageable=true&includeArchived=true"] });
       queryClient.invalidateQueries({ queryKey: ["/api/courses"] });
       toast({
         title: "Course imported",
@@ -116,7 +139,16 @@ export function CourseManagement() {
           <h2 className="text-2xl font-bold" data-testid="text-courses-admin-heading">Learning Courses</h2>
           <p className="text-muted-foreground text-sm">Author courses, modules, and lessons.</p>
         </div>
-        <div className="flex gap-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <div className="flex items-center gap-2">
+            <Switch
+              id="toggle-show-archived"
+              checked={showArchived}
+              onCheckedChange={setShowArchived}
+              data-testid="switch-show-archived-courses"
+            />
+            <Label htmlFor="toggle-show-archived" className="cursor-pointer">Show archived</Label>
+          </div>
           <Button
             variant="outline"
             onClick={() => importFileRef.current?.click()}
@@ -143,15 +175,34 @@ export function CourseManagement() {
       {!isLoading && courses && courses.length > 0 && (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           {courses.map(c => (
-            <Card key={c.id} className="hover-elevate" data-testid={`card-admin-course-${c.id}`}>
+            <Card
+              key={c.id}
+              className={`hover-elevate ${c.status === "archived" ? "opacity-60" : ""}`}
+              data-testid={`card-admin-course-${c.id}`}
+            >
+              {c.imageUrl && (
+                <div className="aspect-video w-full overflow-hidden rounded-t-md">
+                  <img
+                    src={c.imageUrl}
+                    alt={c.title}
+                    className="w-full h-full object-cover"
+                    data-testid={`img-admin-course-${c.id}`}
+                  />
+                </div>
+              )}
               <CardHeader>
                 <div className="flex items-start justify-between gap-2">
                   <div className="flex-1 min-w-0">
                     <CardTitle className="text-base truncate" data-testid={`text-admin-course-title-${c.id}`}>{c.title}</CardTitle>
                     <p className="text-xs text-muted-foreground">/{c.slug}</p>
                   </div>
-                  <div className="flex gap-1">
-                    <Badge variant={c.status === "published" ? "default" : "secondary"}>{c.status}</Badge>
+                  <div className="flex gap-1 flex-wrap">
+                    <Badge
+                      variant={c.status === "published" ? "default" : c.status === "archived" ? "destructive" : "secondary"}
+                      data-testid={`badge-status-${c.id}`}
+                    >
+                      {c.status}
+                    </Badge>
                     <Badge variant="outline">{c.visibility}</Badge>
                   </div>
                 </div>
@@ -339,7 +390,11 @@ function CourseBuilder({ courseId, onClose }: { courseId: string; onClose: () =>
       </div>
 
       {tab === "overview" && (
-        <CourseOverview course={course} onSave={(patch) => updateCourse.mutate(patch)} saving={updateCourse.isPending} />
+        <CourseOverview
+          course={course}
+          onSave={(patch) => updateCourse.mutate(patch)}
+          saving={updateCourse.isPending}
+        />
       )}
 
       {tab === "structure" && (
@@ -456,19 +511,56 @@ function CourseBuilder({ courseId, onClose }: { courseId: string; onClose: () =>
 }
 
 function CourseOverview({ course, onSave, saving }: { course: CourseFull; onSave: (patch: any) => void; saving: boolean }) {
+  const { user } = useAuth();
+  const isGlobalAdmin = user?.role === "global_admin";
+  const { toast } = useToast();
   const [title, setTitle] = useState(course.title);
   const [summary, setSummary] = useState(course.summary || "");
   const [description, setDescription] = useState(course.description);
   const [estimatedMinutes, setEstimatedMinutes] = useState(course.estimatedMinutes?.toString() || "");
   const [status, setStatus] = useState(course.status);
   const [visibility, setVisibility] = useState(course.visibility);
-  const [imageUrl, setImageUrl] = useState(course.imageUrl || "");
   const [passingScore, setPassingScore] = useState(course.passingScore?.toString() || "80");
   const [certificateEnabled, setCertificateEnabled] = useState(course.certificateEnabled);
+  const [showTenantShare, setShowTenantShare] = useState(false);
+
+  const uploadImage = useMutation({
+    mutationFn: async (imageUrl: string) =>
+      apiRequest(`/api/courses/${course.id}/image`, "PUT", { imageUrl }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/courses", course.id] });
+      queryClient.invalidateQueries({ queryKey: ["/api/courses?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/courses?manageable=true&includeArchived=true"] });
+      toast({ title: "Image uploaded" });
+    },
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  const removeImage = useMutation({
+    mutationFn: async () => apiRequest(`/api/courses/${course.id}`, "PUT", { imageUrl: null }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/courses", course.id] });
+      queryClient.invalidateQueries({ queryKey: ["/api/courses?manageable=true"] });
+      queryClient.invalidateQueries({ queryKey: ["/api/courses?manageable=true&includeArchived=true"] });
+      toast({ title: "Image removed" });
+    },
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  const handleGetUploadParameters = async () => {
+    const res = await fetch("/api/objects/upload", { method: "POST", credentials: "include" });
+    const data = await res.json();
+    return { method: "PUT" as const, url: data.uploadURL };
+  };
+
+  const handleUploadComplete = (result: any) => {
+    const url = result?.successful?.[0]?.uploadURL;
+    if (url) uploadImage.mutate(url);
+  };
 
   const handleSave = () => {
     onSave({
-      title, summary: summary || null, description, imageUrl: imageUrl || null,
+      title, summary: summary || null, description,
       estimatedMinutes: estimatedMinutes ? parseInt(estimatedMinutes, 10) : null,
       status, visibility,
       passingScore: parseInt(passingScore, 10),
@@ -478,7 +570,7 @@ function CourseOverview({ course, onSave, saving }: { course: CourseFull; onSave
 
   return (
     <Card>
-      <CardContent className="pt-6 space-y-3">
+      <CardContent className="pt-6 space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
           <div>
             <Label htmlFor="ov-title">Title</Label>
@@ -501,23 +593,73 @@ function CourseOverview({ course, onSave, saving }: { course: CourseFull; onSave
           </div>
           <div>
             <Label htmlFor="ov-visibility">Visibility</Label>
-            <Select value={visibility} onValueChange={v => setVisibility(v as any)}>
+            <Select
+              value={visibility}
+              onValueChange={v => setVisibility(v as any)}
+              disabled={!isGlobalAdmin}
+            >
               <SelectTrigger id="ov-visibility" data-testid="select-overview-visibility"><SelectValue /></SelectTrigger>
               <SelectContent>
                 <SelectItem value="public">Public</SelectItem>
                 <SelectItem value="private">Private (tenant-only)</SelectItem>
               </SelectContent>
             </Select>
+            {!isGlobalAdmin && (
+              <p className="text-xs text-muted-foreground mt-1">Only global admins can change visibility.</p>
+            )}
           </div>
           <div>
             <Label htmlFor="ov-passing">Passing score (0-100)</Label>
             <Input id="ov-passing" type="number" min={0} max={100} value={passingScore} onChange={e => setPassingScore(e.target.value)} data-testid="input-overview-passing" />
           </div>
-          <div>
-            <Label htmlFor="ov-image">Image URL</Label>
-            <Input id="ov-image" value={imageUrl} onChange={e => setImageUrl(e.target.value)} data-testid="input-overview-image" />
-          </div>
         </div>
+
+        {/* Hero image */}
+        <div>
+          <Label>Hero image</Label>
+          <p className="text-sm text-muted-foreground mb-2">
+            Upload an image for this course (recommended: 1200px+ width, 16:9 aspect ratio, under 10MB).
+          </p>
+          {course.imageUrl ? (
+            <div className="space-y-2">
+              <div className="relative rounded-lg overflow-hidden border border-border max-w-md">
+                <img src={course.imageUrl} alt={course.title} className="w-full h-48 object-cover" data-testid="img-course-hero" />
+              </div>
+              <div className="flex gap-2">
+                <ObjectUploader
+                  maxNumberOfFiles={1}
+                  maxFileSize={10485760}
+                  allowedFileTypes={["image/jpeg", "image/png", "image/webp"]}
+                  onGetUploadParameters={handleGetUploadParameters}
+                  onComplete={handleUploadComplete}
+                  buttonVariant="outline"
+                >
+                  <Upload className="h-4 w-4 mr-2" /> Replace image
+                </ObjectUploader>
+                <Button
+                  variant="outline"
+                  onClick={() => removeImage.mutate()}
+                  disabled={removeImage.isPending}
+                  data-testid="button-remove-course-image"
+                >
+                  <X className="h-4 w-4 mr-2" />
+                  {removeImage.isPending ? "Removing..." : "Remove"}
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <ObjectUploader
+              maxNumberOfFiles={1}
+              maxFileSize={10485760}
+              allowedFileTypes={["image/jpeg", "image/png", "image/webp"]}
+              onGetUploadParameters={handleGetUploadParameters}
+              onComplete={handleUploadComplete}
+            >
+              <Upload className="h-4 w-4 mr-2" /> Upload image
+            </ObjectUploader>
+          )}
+        </div>
+
         <div>
           <Label htmlFor="ov-summary">Summary (catalog blurb)</Label>
           <Textarea id="ov-summary" value={summary} onChange={e => setSummary(e.target.value)} data-testid="input-overview-summary" />
@@ -530,6 +672,32 @@ function CourseOverview({ course, onSave, saving }: { course: CourseFull; onSave
           <Switch id="cert" checked={certificateEnabled} onCheckedChange={setCertificateEnabled} data-testid="switch-overview-certificate" />
           <Label htmlFor="cert">Certificate on completion (PDF generation TBD)</Label>
         </div>
+
+        {/* Tenant share — only when private */}
+        {visibility === "private" && (
+          <div className="rounded-md border p-3 bg-muted/30">
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <p className="font-medium">Tenant access</p>
+                <p className="text-sm text-muted-foreground">
+                  Share this private course with selected customer tenants beyond its owner.
+                </p>
+              </div>
+              <Button
+                variant="outline"
+                onClick={() => setShowTenantShare(true)}
+                disabled={!isGlobalAdmin}
+                data-testid="button-manage-course-tenants"
+              >
+                <Share2 className="h-4 w-4 mr-1" /> Manage tenants
+              </Button>
+            </div>
+            {!isGlobalAdmin && (
+              <p className="text-xs text-muted-foreground mt-2">Only global admins can attach courses to other tenants.</p>
+            )}
+          </div>
+        )}
+
         <div className="flex flex-wrap gap-2">
           <Button onClick={handleSave} disabled={saving} data-testid="button-save-overview">
             {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
@@ -545,8 +713,94 @@ function CourseOverview({ course, onSave, saving }: { course: CourseFull; onSave
             <Download className="h-4 w-4 mr-1" /> Export SCORM 1.2
           </Button>
         </div>
+
+        {showTenantShare && (
+          <CourseTenantShareDialog
+            courseId={course.id}
+            onClose={() => setShowTenantShare(false)}
+          />
+        )}
       </CardContent>
     </Card>
+  );
+}
+
+function CourseTenantShareDialog({ courseId, onClose }: { courseId: string; onClose: () => void }) {
+  const { toast } = useToast();
+  const { data: assigned, isLoading } = useQuery<TenantShareRow[]>({
+    queryKey: [`/api/courses/${courseId}/tenants`],
+  });
+  const { data: tenants } = useQuery<TenantOption[]>({
+    queryKey: ["/api/model-tenants"],
+  });
+
+  const addMut = useMutation({
+    mutationFn: async (tenantId: string) =>
+      apiRequest(`/api/courses/${courseId}/tenants`, "POST", { tenantId }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/courses/${courseId}/tenants`] });
+    },
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+  const removeMut = useMutation({
+    mutationFn: async (tenantId: string) =>
+      apiRequest(`/api/courses/${courseId}/tenants/${tenantId}`, "DELETE"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [`/api/courses/${courseId}/tenants`] });
+    },
+    onError: (err: Error) => toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  const assignedIds = new Set((assigned ?? []).map(a => a.tenantId));
+  const sortedTenants = (tenants ?? []).slice().sort((a, b) => a.name.localeCompare(b.name));
+
+  return (
+    <Dialog open onOpenChange={onClose}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Course tenant access</DialogTitle>
+          <DialogDescription>
+            Select which tenants can access this private course. Tenants here are in addition to the course's owning tenant.
+          </DialogDescription>
+        </DialogHeader>
+        {isLoading ? (
+          <Skeleton className="h-32 w-full" />
+        ) : (
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="w-full justify-between" data-testid="select-course-tenants">
+                {assignedIds.size === 0
+                  ? "Select tenants"
+                  : `${assignedIds.size} tenant${assignedIds.size > 1 ? "s" : ""} selected`}
+                <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-[440px]">
+              {sortedTenants.length === 0 ? (
+                <div className="p-2 text-sm text-muted-foreground">No tenants available</div>
+              ) : (
+                sortedTenants.map(t => (
+                  <DropdownMenuCheckboxItem
+                    key={t.id}
+                    checked={assignedIds.has(t.id)}
+                    onCheckedChange={(checked) => {
+                      if (checked) addMut.mutate(t.id);
+                      else removeMut.mutate(t.id);
+                    }}
+                    data-testid={`checkbox-course-tenant-${t.id}`}
+                  >
+                    {t.name}
+                  </DropdownMenuCheckboxItem>
+                ))
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        )}
+        <DialogFooter>
+          <Button onClick={onClose}>Done</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/client/src/pages/Academies.tsx
+++ b/client/src/pages/Academies.tsx
@@ -1,0 +1,86 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { Helmet } from "react-helmet-async";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { GraduationCap, Clock } from "lucide-react";
+import type { Academy } from "@shared/schema";
+
+interface AcademyListItem extends Academy {
+  itemCount: number;
+}
+
+export default function Academies() {
+  const { data: academies, isLoading } = useQuery<AcademyListItem[]>({
+    queryKey: ["/api/academies"],
+  });
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-6xl">
+      <Helmet>
+        <title>Academies | Orion</title>
+        <meta name="description" content="Browse curated learning academies — sequenced paths combining Orion courses with external sources." />
+      </Helmet>
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2" data-testid="text-academies-heading">Academies</h1>
+        <p className="text-muted-foreground">
+          Sequenced learning paths that combine Orion courses with external resources from LinkedIn Learning, Coursera, and more.
+        </p>
+      </div>
+
+      {isLoading && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {[1, 2, 3].map(i => (
+            <Skeleton key={i} className="h-64" data-testid={`skeleton-academy-${i}`} />
+          ))}
+        </div>
+      )}
+
+      {!isLoading && (!academies || academies.length === 0) && (
+        <Card>
+          <CardContent className="pt-6 text-center text-muted-foreground" data-testid="text-academies-empty">
+            No academies available yet. Check back soon.
+          </CardContent>
+        </Card>
+      )}
+
+      {!isLoading && academies && academies.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {academies.map(a => (
+            <Link key={a.id} href={`/academies/${a.slug}`}>
+              <Card className="h-full hover-elevate cursor-pointer" data-testid={`card-academy-${a.id}`}>
+                {a.imageUrl && (
+                  <div className="aspect-video w-full overflow-hidden rounded-t-md">
+                    <img src={a.imageUrl} alt={a.title} className="w-full h-full object-cover" />
+                  </div>
+                )}
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-2 flex-wrap">
+                    <CardTitle className="text-lg" data-testid={`text-academy-title-${a.id}`}>{a.title}</CardTitle>
+                    {a.status !== "published" && <Badge variant="secondary">{a.status}</Badge>}
+                  </div>
+                  {a.summary && <CardDescription>{a.summary}</CardDescription>}
+                </CardHeader>
+                <CardContent>
+                  <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <GraduationCap className="h-4 w-4" />
+                      {a.itemCount} item{a.itemCount === 1 ? "" : "s"}
+                    </span>
+                    {a.estimatedMinutes != null && (
+                      <span className="flex items-center gap-1">
+                        <Clock className="h-4 w-4" />
+                        {a.estimatedMinutes} min
+                      </span>
+                    )}
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/AcademyDetail.tsx
+++ b/client/src/pages/AcademyDetail.tsx
@@ -1,0 +1,179 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link, useRoute } from "wouter";
+import { Helmet } from "react-helmet-async";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft, BookOpen, ExternalLink, Clock } from "lucide-react";
+import type { Academy, AcademyItem, AcademyExternalProvider, Course } from "@shared/schema";
+
+interface AcademyItemWithCourse extends AcademyItem {
+  course?: Pick<Course, "id" | "slug" | "title" | "summary" | "imageUrl" | "estimatedMinutes" | "status" | "visibility"> | null;
+}
+
+interface AcademyFull extends Academy {
+  items: AcademyItemWithCourse[];
+}
+
+const PROVIDER_LABELS: Record<AcademyExternalProvider, string> = {
+  linkedin_learning: "LinkedIn Learning",
+  coursera: "Coursera",
+  pluralsight: "Pluralsight",
+  youtube: "YouTube",
+  udemy: "Udemy",
+  edx: "edX",
+  other: "External",
+};
+
+export default function AcademyDetail() {
+  const [, params] = useRoute<{ slug: string }>("/academies/:slug");
+  const slug = params?.slug;
+
+  const { data: academy, isLoading, error } = useQuery<AcademyFull>({
+    queryKey: [`/api/academies/${slug}`],
+    enabled: !!slug,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <Skeleton className="h-64 w-full mb-4" />
+        <Skeleton className="h-8 w-1/2 mb-2" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+    );
+  }
+
+  if (error || !academy) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <Card>
+          <CardContent className="pt-6 text-center" data-testid="text-academy-not-found">
+            <p className="text-muted-foreground">Academy not found or you don't have access.</p>
+            <Link href="/academies">
+              <Button variant="outline" className="mt-4">Back to academies</Button>
+            </Link>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <Helmet>
+        <title>{academy.title} | Academies</title>
+        {academy.summary && <meta name="description" content={academy.summary} />}
+      </Helmet>
+
+      <Link href="/academies">
+        <Button variant="ghost" size="sm" className="mb-4" data-testid="button-back-to-academies">
+          <ArrowLeft className="h-4 w-4 mr-1" /> All academies
+        </Button>
+      </Link>
+
+      {academy.imageUrl && (
+        <div className="aspect-video w-full overflow-hidden rounded-lg mb-6">
+          <img src={academy.imageUrl} alt={academy.title} className="w-full h-full object-cover" data-testid="img-academy-hero" />
+        </div>
+      )}
+
+      <div className="flex items-start justify-between gap-3 mb-2 flex-wrap">
+        <h1 className="text-3xl font-bold" data-testid="text-academy-title">{academy.title}</h1>
+        {academy.status !== "published" && <Badge variant="secondary">{academy.status}</Badge>}
+      </div>
+      {academy.summary && <p className="text-muted-foreground mb-4" data-testid="text-academy-summary">{academy.summary}</p>}
+      {academy.description && (
+        <div className="prose dark:prose-invert max-w-none mb-8" data-testid="text-academy-description">
+          <p className="whitespace-pre-wrap">{academy.description}</p>
+        </div>
+      )}
+
+      <h2 className="text-xl font-semibold mb-3">Learning sequence</h2>
+      {academy.items.length === 0 && (
+        <Card>
+          <CardContent className="pt-6 text-muted-foreground">No items in this academy yet.</CardContent>
+        </Card>
+      )}
+      <div className="space-y-3">
+        {academy.items.map((item, idx) => (
+          <AcademyItemCard key={item.id} item={item} index={idx} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AcademyItemCard({ item, index }: { item: AcademyItemWithCourse; index: number }) {
+  if (item.itemType === "course") {
+    if (!item.course) {
+      return (
+        <Card data-testid={`card-academy-item-${item.id}`}>
+          <CardContent className="pt-6 text-muted-foreground">
+            <span className="font-mono mr-2">{index + 1}.</span>
+            Course unavailable.
+          </CardContent>
+        </Card>
+      );
+    }
+    return (
+      <Link href={`/courses/${item.course.slug}`}>
+        <Card className="hover-elevate cursor-pointer" data-testid={`card-academy-item-${item.id}`}>
+          <CardHeader>
+            <div className="flex items-start gap-3">
+              <span className="font-mono text-muted-foreground w-8 shrink-0">{index + 1}.</span>
+              <BookOpen className="h-5 w-5 text-primary shrink-0 mt-0.5" />
+              <div className="flex-1 min-w-0">
+                <CardTitle className="text-base">{item.course.title}</CardTitle>
+                {item.course.summary && (
+                  <p className="text-sm text-muted-foreground mt-1">{item.course.summary}</p>
+                )}
+                <div className="flex items-center gap-3 text-xs text-muted-foreground mt-2">
+                  <span>Orion course</span>
+                  {item.course.estimatedMinutes != null && (
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {item.course.estimatedMinutes} min
+                    </span>
+                  )}
+                  {item.required && <Badge variant="outline">required</Badge>}
+                </div>
+              </div>
+            </div>
+          </CardHeader>
+        </Card>
+      </Link>
+    );
+  }
+
+  // External item
+  return (
+    <a href={item.externalUrl ?? "#"} target="_blank" rel="noopener noreferrer">
+      <Card className="hover-elevate cursor-pointer" data-testid={`card-academy-item-${item.id}`}>
+        <CardHeader>
+          <div className="flex items-start gap-3">
+            <span className="font-mono text-muted-foreground w-8 shrink-0">{index + 1}.</span>
+            <ExternalLink className="h-5 w-5 text-primary shrink-0 mt-0.5" />
+            <div className="flex-1 min-w-0">
+              <CardTitle className="text-base">{item.externalTitle}</CardTitle>
+              {item.externalDescription && (
+                <p className="text-sm text-muted-foreground mt-1">{item.externalDescription}</p>
+              )}
+              <div className="flex items-center gap-3 text-xs text-muted-foreground mt-2">
+                <span>{PROVIDER_LABELS[item.externalProvider as AcademyExternalProvider] ?? "External"}</span>
+                {item.externalDurationMinutes != null && (
+                  <span className="flex items-center gap-1">
+                    <Clock className="h-3 w-3" />
+                    {item.externalDurationMinutes} min
+                  </span>
+                )}
+                {item.required && <Badge variant="outline">required</Badge>}
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+      </Card>
+    </a>
+  );
+}

--- a/client/src/pages/Admin.tsx
+++ b/client/src/pages/Admin.tsx
@@ -80,6 +80,9 @@ const BrandingPanel = lazy(() =>
 const CourseManagement = lazy(() =>
   import("@/components/admin/CourseManagement").then((m) => ({ default: m.CourseManagement })),
 );
+const AcademyManagement = lazy(() =>
+  import("@/components/admin/AcademyManagement").then((m) => ({ default: m.AcademyManagement })),
+);
 
 function SectionFallback() {
   return (
@@ -2626,6 +2629,17 @@ export default function Admin() {
                       <span className="group-data-[collapsible=icon]:hidden">Courses</span>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
+                  <SidebarMenuItem>
+                    <SidebarMenuButton
+                      onClick={() => setActiveSection('academies')}
+                      isActive={activeSection === 'academies'}
+                      data-testid="tab-academies"
+                      tooltip="Academies"
+                    >
+                      <GraduationCap className="h-4 w-4" />
+                      <span className="group-data-[collapsible=icon]:hidden">Academies</span>
+                    </SidebarMenuButton>
+                  </SidebarMenuItem>
                 </SidebarMenu>
               </SidebarGroupContent>
             </SidebarGroup>
@@ -4352,6 +4366,10 @@ export default function Admin() {
 
               {activeSection === 'courses' && (
                 <CourseManagement />
+              )}
+
+              {activeSection === 'academies' && (
+                <AcademyManagement />
               )}
 
               {activeSection === 'ai-usage' && (

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -13,6 +13,7 @@ import { registerAdminRoutes } from "./routes/admin-routes";
 import { registerOgRoutes } from "./routes/og-routes";
 import { registerGalaxyRoutes, registerGalaxyAdminRoutes, registerGalaxyPortalRoutes, registerGalaxyPortalAdminRoutes } from "./routes/galaxy";
 import { registerCourseRoutes } from "./routes/course-routes";
+import { registerAcademyRoutes } from "./routes/academy-routes";
 
 export async function registerRoutes(app: Express): Promise<Server> {
   // Set up authentication routes (includes session setup)
@@ -40,6 +41,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   registerGalaxyPortalRoutes(app);
   registerGalaxyPortalAdminRoutes(app);
   registerCourseRoutes(app);
+  registerAcademyRoutes(app);
 
   const httpServer = createServer(app);
   return httpServer;

--- a/server/routes/academy-routes.ts
+++ b/server/routes/academy-routes.ts
@@ -1,0 +1,319 @@
+/**
+ * Academy routes — Academies (Learning Sequences) API.
+ *
+ * Mirrors course-routes.ts authorization model:
+ *  - Catalog read: visibility filter via academy_tenants + ownerTenantId.
+ *  - Mutations: must be global admin OR an admin/modeler in the academy's
+ *    owning tenant. Tenant-side users cannot change ownerTenantId or
+ *    visibility — only global admins can.
+ *  - Tenant share endpoints (`/api/academies/:id/tenants`) require global
+ *    admin (matches the model-tenants pattern).
+ *  - Delete is archive-by-default; ?hard=true + global admin to hard delete.
+ */
+
+import type { Express, Request, Response } from "express";
+import { z } from "zod";
+import { ensureAdminOrModeler } from "../auth";
+import { getAccessibleTenantIds, checkIsGlobalAdmin } from "../permissions";
+import * as academySvc from "../services/academy-service";
+import * as schema from "@shared/schema";
+
+async function requireManageAcademy(req: Request, res: Response, id: string): Promise<schema.Academy | null> {
+  const user = req.user as schema.User | undefined;
+  const academy = await academySvc.getAcademyById(id);
+  if (!academy) {
+    res.status(404).json({ error: "Academy not found" });
+    return null;
+  }
+  if (!academySvc.userCanManageAcademy(user, academy)) {
+    res.status(403).json({ error: "Forbidden" });
+    return null;
+  }
+  return academy;
+}
+
+export function registerAcademyRoutes(app: Express) {
+  // ---- Public/learner list ----
+  app.get("/api/academies", async (req, res) => {
+    try {
+      const user = req.user as schema.User | undefined;
+      let tenantIds: string[] | null = [];
+      let canSeeUnpublished = false;
+      if (user) {
+        if (checkIsGlobalAdmin(user)) {
+          tenantIds = null;
+          canSeeUnpublished = true;
+        } else {
+          const accessible = getAccessibleTenantIds(user) ?? [];
+          const set = new Set<string>(accessible);
+          if (user.tenantId) set.add(user.tenantId);
+          tenantIds = Array.from(set);
+          if (user.role === "tenant_admin" || user.role === "tenant_modeler") {
+            canSeeUnpublished = true;
+          }
+        }
+      }
+      const manageable = req.query.manageable === "true";
+      if (manageable) {
+        if (!user) return res.status(401).json({ error: "Unauthorized" });
+        const ownerOnly = checkIsGlobalAdmin(user) ? null : (tenantIds ?? []);
+        const includeArchived = req.query.includeArchived === "true";
+        const statuses = includeArchived
+          ? ["draft", "published", "archived"]
+          : ["draft", "published"];
+        const all = await academySvc.listAcademiesOwnedBy(ownerOnly, statuses);
+        return res.json(all);
+      }
+      const published = await academySvc.listAcademies({ tenantIds, status: "published" });
+      let payload = published;
+      if (canSeeUnpublished && user) {
+        const ownerOnly = checkIsGlobalAdmin(user) ? null : (tenantIds ?? []);
+        if (ownerOnly === null || ownerOnly.length > 0) {
+          const drafts = await academySvc.listAcademiesOwnedBy(ownerOnly, ["draft"]);
+          const seen = new Set(payload.map(a => a.id));
+          payload = [...payload, ...drafts.filter(d => !seen.has(d.id))];
+        }
+      }
+      res.json(payload);
+    } catch (err: any) {
+      console.error("list academies error", err);
+      res.status(500).json({ error: err.message ?? "Failed to list academies" });
+    }
+  });
+
+  app.get("/api/academies/:idOrSlug", async (req, res) => {
+    try {
+      const academy = await academySvc.getAcademyFull(req.params.idOrSlug);
+      if (!academy) return res.status(404).json({ error: "Academy not found" });
+      const user = req.user as schema.User | undefined;
+      const canView = await academySvc.userCanViewAcademy(user, academy);
+      if (!canView) return res.status(403).json({ error: "Forbidden" });
+      if (academy.status !== "published") {
+        if (!academySvc.userCanManageAcademy(user, academy)) {
+          return res.status(404).json({ error: "Academy not found" });
+        }
+      }
+      res.json(academy);
+    } catch (err: any) {
+      console.error("get academy error", err);
+      res.status(500).json({ error: err.message ?? "Failed to fetch academy" });
+    }
+  });
+
+  // ---- Mutations ----
+  app.post("/api/academies", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      const isGlobal = checkIsGlobalAdmin(user);
+      const ownerTenantId = isGlobal
+        ? (req.body.ownerTenantId ?? null)
+        : (user.tenantId ?? null);
+      if (!isGlobal && !user.tenantId) {
+        return res.status(403).json({ error: "Tenant admins must be assigned to a tenant" });
+      }
+      const parsed = schema.insertAcademySchema.parse({
+        ...req.body,
+        createdBy: user.id,
+        ownerTenantId,
+      });
+      const academy = await academySvc.createAcademy(parsed);
+      res.json(academy);
+    } catch (err: any) {
+      console.error("create academy error", err);
+      res.status(400).json({ error: err.message ?? "Failed to create academy" });
+    }
+  });
+
+  app.put("/api/academies/:id", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      const academy = await requireManageAcademy(req, res, req.params.id);
+      if (!academy) return;
+      const isGlobal = checkIsGlobalAdmin(user);
+      const { ownerTenantId, visibility, ...rest } = req.body;
+      const patch: any = { ...rest };
+      if (isGlobal) {
+        if (ownerTenantId !== undefined) patch.ownerTenantId = ownerTenantId;
+        if (visibility !== undefined) patch.visibility = visibility;
+      } else {
+        if (ownerTenantId !== undefined && ownerTenantId !== academy.ownerTenantId) {
+          return res.status(403).json({ error: "Only global admins can change an academy's owner tenant" });
+        }
+        if (visibility !== undefined && visibility !== academy.visibility) {
+          return res.status(403).json({ error: "Only global admins can change an academy's visibility" });
+        }
+      }
+      const updated = await academySvc.updateAcademy(academy.id, patch);
+      if (!updated) return res.status(404).json({ error: "Academy not found" });
+      res.json(updated);
+    } catch (err: any) {
+      res.status(400).json({ error: err.message ?? "Failed to update academy" });
+    }
+  });
+
+  app.delete("/api/academies/:id", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      const academy = await requireManageAcademy(req, res, req.params.id);
+      if (!academy) return;
+      const hard = req.query.hard === "true";
+      if (hard) {
+        if (!checkIsGlobalAdmin(user)) {
+          return res.status(403).json({ error: "Only global admins can hard-delete an academy" });
+        }
+        await academySvc.deleteAcademy(academy.id);
+        return res.json({ success: true, deleted: true });
+      }
+      const archived = await academySvc.archiveAcademy(academy.id);
+      res.json({ success: true, archived: true, academy: archived });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  // ---- Image ----
+  app.put("/api/academies/:id/image", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const { imageUrl } = req.body;
+      if (!imageUrl) return res.status(400).json({ error: "imageUrl is required" });
+      const academy = await requireManageAcademy(req, res, req.params.id);
+      if (!academy) return;
+      const user = req.user as schema.User;
+      const { ObjectStorageService } = await import("../objectStorage");
+      const objectStorageService = new ObjectStorageService();
+      const normalizedPath = await objectStorageService.trySetObjectEntityAclPolicy(
+        imageUrl,
+        { owner: user.id || "admin", visibility: "public" },
+      );
+      const updated = await academySvc.updateAcademy(academy.id, { imageUrl: normalizedPath } as any);
+      if (!updated) return res.status(404).json({ error: "Academy not found" });
+      res.json(updated);
+    } catch (err: any) {
+      console.error("update academy image error", err);
+      res.status(500).json({ error: err.message ?? "Failed to update academy image" });
+    }
+  });
+
+  // ---- Items ----
+  const itemBodySchema = z.object({
+    itemType: z.enum(schema.ACADEMY_ITEM_TYPES),
+    courseId: z.string().nullable().optional(),
+    externalProvider: z.enum(schema.ACADEMY_EXTERNAL_PROVIDERS).nullable().optional(),
+    externalTitle: z.string().nullable().optional(),
+    externalUrl: z.string().url().nullable().optional(),
+    externalDurationMinutes: z.number().int().min(0).nullable().optional(),
+    externalDescription: z.string().nullable().optional(),
+    required: z.boolean().optional(),
+    order: z.number().int().min(0).optional(),
+  });
+
+  app.post("/api/academies/:id/items", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const academy = await requireManageAcademy(req, res, req.params.id);
+      if (!academy) return;
+      const parsed = itemBodySchema.parse(req.body);
+      if (parsed.itemType === "course" && !parsed.courseId) {
+        return res.status(400).json({ error: "courseId is required for course items" });
+      }
+      if (parsed.itemType === "external" && (!parsed.externalUrl || !parsed.externalTitle)) {
+        return res.status(400).json({ error: "externalTitle and externalUrl are required for external items" });
+      }
+      const item = await academySvc.createAcademyItem({
+        ...parsed,
+        academyId: academy.id,
+      } as any);
+      res.json(item);
+    } catch (err: any) {
+      res.status(400).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  app.put("/api/academy-items/:id", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      const academy = await academySvc.getAcademyForItem(req.params.id);
+      if (!academy) return res.status(404).json({ error: "Item not found" });
+      if (!academySvc.userCanManageAcademy(user, academy)) return res.status(403).json({ error: "Forbidden" });
+      const parsed = itemBodySchema.partial().parse(req.body);
+      const updated = await academySvc.updateAcademyItem(req.params.id, parsed as any);
+      if (!updated) return res.status(404).json({ error: "Not found" });
+      res.json(updated);
+    } catch (err: any) {
+      res.status(400).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  app.delete("/api/academy-items/:id", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      const academy = await academySvc.getAcademyForItem(req.params.id);
+      if (!academy) return res.status(404).json({ error: "Item not found" });
+      if (!academySvc.userCanManageAcademy(user, academy)) return res.status(403).json({ error: "Forbidden" });
+      await academySvc.deleteAcademyItem(req.params.id);
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  app.put("/api/academies/:id/items/reorder", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const academy = await requireManageAcademy(req, res, req.params.id);
+      if (!academy) return;
+      const { orderedIds } = req.body as { orderedIds?: string[] };
+      if (!Array.isArray(orderedIds)) {
+        return res.status(400).json({ error: "orderedIds must be an array" });
+      }
+      await academySvc.reorderAcademyItems(academy.id, orderedIds);
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  // ---- Tenant share ----
+  app.get("/api/academies/:id/tenants", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const academy = await requireManageAcademy(req, res, req.params.id);
+      if (!academy) return;
+      const rows = await academySvc.listAcademyTenants(academy.id);
+      res.json(rows);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  app.post("/api/academies/:id/tenants", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      if (!checkIsGlobalAdmin(user)) {
+        return res.status(403).json({ error: "Only global admins can manage academy tenant access" });
+      }
+      const academy = await requireManageAcademy(req, res, req.params.id);
+      if (!academy) return;
+      const { tenantId } = req.body;
+      if (!tenantId) return res.status(400).json({ error: "tenantId is required" });
+      const row = await academySvc.addAcademyTenant(academy.id, tenantId);
+      res.status(201).json(row);
+    } catch (err: any) {
+      console.error("add academy tenant error", err);
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  app.delete("/api/academies/:id/tenants/:tenantId", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      if (!checkIsGlobalAdmin(user)) {
+        return res.status(403).json({ error: "Only global admins can manage academy tenant access" });
+      }
+      const academy = await requireManageAcademy(req, res, req.params.id);
+      if (!academy) return;
+      const ok = await academySvc.removeAcademyTenant(academy.id, req.params.tenantId);
+      if (!ok) return res.status(404).json({ error: "Tenant assignment not found" });
+      res.json({ success: true });
+    } catch (err: any) {
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+}

--- a/server/routes/academy-routes.ts
+++ b/server/routes/academy-routes.ts
@@ -83,9 +83,12 @@ export function registerAcademyRoutes(app: Express) {
 
   app.get("/api/academies/:idOrSlug", async (req, res) => {
     try {
-      const academy = await academySvc.getAcademyFull(req.params.idOrSlug);
-      if (!academy) return res.status(404).json({ error: "Academy not found" });
       const user = req.user as schema.User | undefined;
+      // Pass the caller into getAcademyFull so per-item course hydration
+      // respects course visibility — private/tenant-only courses the user
+      // can't see are returned as `course: null`.
+      const academy = await academySvc.getAcademyFull(req.params.idOrSlug, user);
+      if (!academy) return res.status(404).json({ error: "Academy not found" });
       const canView = await academySvc.userCanViewAcademy(user, academy);
       if (!canView) return res.status(403).json({ error: "Forbidden" });
       if (academy.status !== "published") {
@@ -239,8 +242,50 @@ export function registerAcademyRoutes(app: Express) {
       const academy = await academySvc.getAcademyForItem(req.params.id);
       if (!academy) return res.status(404).json({ error: "Item not found" });
       if (!academySvc.userCanManageAcademy(user, academy)) return res.status(403).json({ error: "Forbidden" });
+      const existing = await academySvc.getAcademyItem(req.params.id);
+      if (!existing) return res.status(404).json({ error: "Item not found" });
       const parsed = itemBodySchema.partial().parse(req.body);
-      const updated = await academySvc.updateAcademyItem(req.params.id, parsed as any);
+      // Compute the post-update state and re-validate type/field invariants.
+      // When `itemType` flips, also clear the fields that no longer apply so
+      // a course→external switch doesn't keep a stale `courseId`, and vice
+      // versa. Without this guard the row can end up internally inconsistent
+      // (e.g. itemType='course' with no courseId, or itemType='external'
+      // missing externalUrl/title) and break the learner UI.
+      const merged: any = { ...existing, ...parsed };
+      const finalType = (parsed.itemType ?? existing.itemType) as schema.AcademyItemType;
+      const typeChanged = parsed.itemType !== undefined && parsed.itemType !== existing.itemType;
+      if (typeChanged) {
+        if (finalType === "course") {
+          merged.externalProvider = null;
+          merged.externalTitle = null;
+          merged.externalUrl = null;
+          merged.externalDurationMinutes = null;
+          merged.externalDescription = null;
+        } else if (finalType === "external") {
+          merged.courseId = null;
+        }
+      }
+      if (finalType === "course" && !merged.courseId) {
+        return res.status(400).json({ error: "courseId is required for course items" });
+      }
+      if (finalType === "external" && (!merged.externalUrl || !merged.externalTitle)) {
+        return res.status(400).json({ error: "externalTitle and externalUrl are required for external items" });
+      }
+      // Build the patch to send to the DB: anything in `parsed` plus any
+      // fields we cleared on a type change.
+      const patch: any = { ...parsed };
+      if (typeChanged) {
+        if (finalType === "course") {
+          patch.externalProvider = null;
+          patch.externalTitle = null;
+          patch.externalUrl = null;
+          patch.externalDurationMinutes = null;
+          patch.externalDescription = null;
+        } else if (finalType === "external") {
+          patch.courseId = null;
+        }
+      }
+      const updated = await academySvc.updateAcademyItem(req.params.id, patch);
       if (!updated) return res.status(404).json({ error: "Not found" });
       res.json(updated);
     } catch (err: any) {

--- a/server/routes/academy-routes.ts
+++ b/server/routes/academy-routes.ts
@@ -111,8 +111,13 @@ export function registerAcademyRoutes(app: Express) {
       if (!isGlobal && !user.tenantId) {
         return res.status(403).json({ error: "Tenant admins must be assigned to a tenant" });
       }
+      // Visibility is a global-admin field at create time too — keeps create
+      // consistent with the PUT route, which rejects visibility changes from
+      // tenant-side users. Non-global users get the schema default ('private').
+      const { visibility: _vis, ...createBody } = req.body;
       const parsed = schema.insertAcademySchema.parse({
-        ...req.body,
+        ...createBody,
+        ...(isGlobal && _vis !== undefined ? { visibility: _vis } : {}),
         createdBy: user.id,
         ownerTenantId,
       });
@@ -261,8 +266,27 @@ export function registerAcademyRoutes(app: Express) {
       const academy = await requireManageAcademy(req, res, req.params.id);
       if (!academy) return;
       const { orderedIds } = req.body as { orderedIds?: string[] };
-      if (!Array.isArray(orderedIds)) {
-        return res.status(400).json({ error: "orderedIds must be an array" });
+      if (!Array.isArray(orderedIds) || orderedIds.some((x) => typeof x !== "string")) {
+        return res.status(400).json({ error: "orderedIds must be an array of item ids" });
+      }
+      // Reorder must be a full permutation of this academy's current items —
+      // no duplicates, no foreign IDs, no missing IDs. Otherwise the
+      // transaction silently leaves rows with stale `order` values.
+      const currentIds = await academySvc.listAcademyItemIds(academy.id);
+      if (orderedIds.length !== currentIds.length) {
+        return res.status(400).json({
+          error: "orderedIds must contain every current item exactly once",
+        });
+      }
+      const submitted = new Set(orderedIds);
+      if (submitted.size !== orderedIds.length) {
+        return res.status(400).json({ error: "orderedIds contains duplicate ids" });
+      }
+      const known = new Set(currentIds);
+      for (const id of orderedIds) {
+        if (!known.has(id)) {
+          return res.status(400).json({ error: `id '${id}' does not belong to this academy` });
+        }
       }
       await academySvc.reorderAcademyItems(academy.id, orderedIds);
       res.json({ success: true });
@@ -272,8 +296,15 @@ export function registerAcademyRoutes(app: Express) {
   });
 
   // ---- Tenant share ----
+  // All operations are global-admin only — assignments expose other tenants'
+  // names/IDs, so non-global managers (who can edit an academy they own)
+  // shouldn't see the share list. Mirrors /api/models/:id/tenants.
   app.get("/api/academies/:id/tenants", ensureAdminOrModeler, async (req, res) => {
     try {
+      const user = req.user as schema.User;
+      if (!checkIsGlobalAdmin(user)) {
+        return res.status(403).json({ error: "Only global admins can view academy tenant access" });
+      }
       const academy = await requireManageAcademy(req, res, req.params.id);
       if (!academy) return;
       const rows = await academySvc.listAcademyTenants(academy.id);
@@ -293,8 +324,10 @@ export function registerAcademyRoutes(app: Express) {
       if (!academy) return;
       const { tenantId } = req.body;
       if (!tenantId) return res.status(400).json({ error: "tenantId is required" });
-      const row = await academySvc.addAcademyTenant(academy.id, tenantId);
-      res.status(201).json(row);
+      const result = await academySvc.addAcademyTenant(academy.id, tenantId);
+      if (result.created) return res.status(201).json(result.row);
+      if (result.row) return res.status(200).json(result.row);
+      return res.status(409).json({ error: "Tenant assignment was concurrently removed" });
     } catch (err: any) {
       console.error("add academy tenant error", err);
       res.status(500).json({ error: err.message ?? "Failed" });

--- a/server/routes/course-routes.ts
+++ b/server/routes/course-routes.ts
@@ -582,10 +582,15 @@ export function registerCourseRoutes(app: Express) {
   });
 
   // ----- Course ↔ tenant share (private courses) -----
-  // Mirrors /api/models/:id/tenants. Manage which tenants can see a
-  // private course by maintaining the course_tenants junction.
+  // Mirrors /api/models/:id/tenants. All operations are global-admin only:
+  // tenant assignments expose other tenants' names/IDs, so non-global
+  // managers (who can edit a course they own) shouldn't see the share list.
   app.get("/api/courses/:id/tenants", ensureAdminOrModeler, async (req, res) => {
     try {
+      const user = req.user as schema.User;
+      if (!checkIsGlobalAdmin(user)) {
+        return res.status(403).json({ error: "Only global admins can view course tenant access" });
+      }
       const course = await requireManageCourse(req, res, req.params.id);
       if (!course) return;
       const rows = await courseSvc.listCourseTenants(course.id);
@@ -598,8 +603,6 @@ export function registerCourseRoutes(app: Express) {
   app.post("/api/courses/:id/tenants", ensureAdminOrModeler, async (req, res) => {
     try {
       const user = req.user as schema.User;
-      // Tenant assignment for cross-tenant access is a global-admin operation
-      // (matches the model-tenants endpoints).
       if (!checkIsGlobalAdmin(user)) {
         return res.status(403).json({ error: "Only global admins can manage course tenant access" });
       }
@@ -607,8 +610,12 @@ export function registerCourseRoutes(app: Express) {
       if (!course) return;
       const { tenantId } = req.body;
       if (!tenantId) return res.status(400).json({ error: "tenantId is required" });
-      const row = await courseSvc.addCourseTenant(course.id, tenantId);
-      res.status(201).json(row);
+      const result = await courseSvc.addCourseTenant(course.id, tenantId);
+      // 201 only when the row was newly created. If the assignment already
+      // existed, return 200 with the existing row. Race deletion → 409.
+      if (result.created) return res.status(201).json(result.row);
+      if (result.row) return res.status(200).json(result.row);
+      return res.status(409).json({ error: "Tenant assignment was concurrently removed" });
     } catch (err: any) {
       console.error("add course tenant error", err);
       res.status(500).json({ error: err.message ?? "Failed" });

--- a/server/routes/course-routes.ts
+++ b/server/routes/course-routes.ts
@@ -105,11 +105,16 @@ export function registerCourseRoutes(app: Express) {
       const manageable = req.query.manageable === "true";
       if (manageable) {
         // Authoring view: courses the caller can manage. Global admins see
-        // all; tenant admins/modelers see only courses owned by their tenants
-        // (any status).
+        // all; tenant admins/modelers see only courses owned by their tenants.
+        // Archived courses are hidden by default; pass ?includeArchived=true
+        // to include them.
         if (!user) return res.status(401).json({ error: "Unauthorized" });
         const ownerOnly = checkIsGlobalAdmin(user) ? null : (tenantIds ?? []);
-        const all = await courseSvc.listCoursesOwnedBy(ownerOnly, ["draft", "published", "archived"]);
+        const includeArchived = req.query.includeArchived === "true";
+        const statuses = includeArchived
+          ? ["draft", "published", "archived"]
+          : ["draft", "published"];
+        const all = await courseSvc.listCoursesOwnedBy(ownerOnly, statuses);
         return res.json(all);
       }
       const published = await courseSvc.listCourses({ tenantIds, status: "published" });
@@ -546,6 +551,81 @@ export function registerCourseRoutes(app: Express) {
       if (!course) return;
       const enrollments = await courseSvc.listEnrollmentsForCourse(course.id);
       res.json(enrollments);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  // Update a course's image. The body may contain a freshly-uploaded
+  // object-storage URL; we set its ACL to public and persist the
+  // normalized path on the course row. Mirrors /api/models/:id/image.
+  app.put("/api/courses/:id/image", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const { imageUrl } = req.body;
+      if (!imageUrl) return res.status(400).json({ error: "imageUrl is required" });
+      const course = await requireManageCourse(req, res, req.params.id);
+      if (!course) return;
+      const user = req.user as schema.User;
+      const { ObjectStorageService } = await import("../objectStorage");
+      const objectStorageService = new ObjectStorageService();
+      const normalizedPath = await objectStorageService.trySetObjectEntityAclPolicy(
+        imageUrl,
+        { owner: user.id || "admin", visibility: "public" },
+      );
+      const updated = await courseSvc.updateCourse(course.id, { imageUrl: normalizedPath } as any);
+      if (!updated) return res.status(404).json({ error: "Course not found" });
+      res.json(updated);
+    } catch (err: any) {
+      console.error("update course image error", err);
+      res.status(500).json({ error: err.message ?? "Failed to update course image" });
+    }
+  });
+
+  // ----- Course ↔ tenant share (private courses) -----
+  // Mirrors /api/models/:id/tenants. Manage which tenants can see a
+  // private course by maintaining the course_tenants junction.
+  app.get("/api/courses/:id/tenants", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const course = await requireManageCourse(req, res, req.params.id);
+      if (!course) return;
+      const rows = await courseSvc.listCourseTenants(course.id);
+      res.json(rows);
+    } catch (err: any) {
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  app.post("/api/courses/:id/tenants", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      // Tenant assignment for cross-tenant access is a global-admin operation
+      // (matches the model-tenants endpoints).
+      if (!checkIsGlobalAdmin(user)) {
+        return res.status(403).json({ error: "Only global admins can manage course tenant access" });
+      }
+      const course = await requireManageCourse(req, res, req.params.id);
+      if (!course) return;
+      const { tenantId } = req.body;
+      if (!tenantId) return res.status(400).json({ error: "tenantId is required" });
+      const row = await courseSvc.addCourseTenant(course.id, tenantId);
+      res.status(201).json(row);
+    } catch (err: any) {
+      console.error("add course tenant error", err);
+      res.status(500).json({ error: err.message ?? "Failed" });
+    }
+  });
+
+  app.delete("/api/courses/:id/tenants/:tenantId", ensureAdminOrModeler, async (req, res) => {
+    try {
+      const user = req.user as schema.User;
+      if (!checkIsGlobalAdmin(user)) {
+        return res.status(403).json({ error: "Only global admins can manage course tenant access" });
+      }
+      const course = await requireManageCourse(req, res, req.params.id);
+      if (!course) return;
+      const ok = await courseSvc.removeCourseTenant(course.id, req.params.tenantId);
+      if (!ok) return res.status(404).json({ error: "Tenant assignment not found" });
+      res.json({ success: true });
     } catch (err: any) {
       res.status(500).json({ error: err.message ?? "Failed" });
     }

--- a/server/services/academy-service.ts
+++ b/server/services/academy-service.ts
@@ -122,7 +122,7 @@ export async function getAcademyById(id: string): Promise<Academy | null> {
   return row ?? null;
 }
 
-export async function getAcademyFull(idOrSlug: string): Promise<AcademyFull | null> {
+export async function getAcademyFull(idOrSlug: string, user?: schema.User): Promise<AcademyFull | null> {
   const [academy] = await db.select().from(schema.academies)
     .where(or(eq(schema.academies.id, idOrSlug), eq(schema.academies.slug, idOrSlug)))
     .limit(1);
@@ -132,21 +132,35 @@ export async function getAcademyFull(idOrSlug: string): Promise<AcademyFull | nu
     .orderBy(schema.academyItems.order);
 
   const courseIds = items.map(i => i.courseId).filter((id): id is string => !!id);
+  // Fetch the full course row including ownerTenantId so we can apply the
+  // same per-course visibility check that the catalog/detail endpoints
+  // use. Public/shared courses pass through; courses the caller can't view
+  // are returned as `course: null` so the UI hides the link instead of
+  // exposing private metadata or producing a dead "forbidden" link.
   const courseRows = courseIds.length > 0
-    ? await db.select({
-        id: schema.courses.id,
-        slug: schema.courses.slug,
-        title: schema.courses.title,
-        summary: schema.courses.summary,
-        imageUrl: schema.courses.imageUrl,
-        estimatedMinutes: schema.courses.estimatedMinutes,
-        status: schema.courses.status,
-        visibility: schema.courses.visibility,
-      })
-        .from(schema.courses)
+    ? await db.select().from(schema.courses)
         .where(inArray(schema.courses.id, courseIds))
     : [];
-  const courseById = new Map(courseRows.map(c => [c.id, c]));
+
+  const visibleCourseIds = new Set<string>();
+  for (const c of courseRows) {
+    if (await userCanViewCourseRow(user, c)) visibleCourseIds.add(c.id);
+  }
+
+  const courseById = new Map(
+    courseRows
+      .filter(c => visibleCourseIds.has(c.id))
+      .map(c => [c.id, {
+        id: c.id,
+        slug: c.slug,
+        title: c.title,
+        summary: c.summary,
+        imageUrl: c.imageUrl,
+        estimatedMinutes: c.estimatedMinutes,
+        status: c.status,
+        visibility: c.visibility,
+      }]),
+  );
 
   const hydrated: AcademyItemHydrated[] = items.map(i => ({
     ...i,
@@ -154,6 +168,26 @@ export async function getAcademyFull(idOrSlug: string): Promise<AcademyFull | nu
   }));
 
   return { ...academy, items: hydrated };
+}
+
+// Local copy of the course-visibility check, inlined to avoid a circular
+// import between course-service and academy-service. Keep in sync with
+// `courseSvc.userCanViewCourse`.
+async function userCanViewCourseRow(user: schema.User | undefined, course: schema.Course): Promise<boolean> {
+  if (course.visibility === "public") return true;
+  if (!user) return false;
+  if (user.role === "global_admin") return true;
+  if (user.tenantId && course.ownerTenantId === user.tenantId) return true;
+  if (user.tenantId) {
+    const [shared] = await db.select().from(schema.courseTenants)
+      .where(and(
+        eq(schema.courseTenants.courseId, course.id),
+        eq(schema.courseTenants.tenantId, user.tenantId),
+      ))
+      .limit(1);
+    if (shared) return true;
+  }
+  return false;
 }
 
 export async function createAcademy(data: InsertAcademy): Promise<Academy> {
@@ -183,6 +217,12 @@ export async function deleteAcademy(id: string): Promise<void> {
 export async function createAcademyItem(data: InsertAcademyItem): Promise<AcademyItem> {
   const [row] = await db.insert(schema.academyItems).values(data as any).returning();
   return row;
+}
+
+export async function getAcademyItem(id: string): Promise<AcademyItem | null> {
+  const [row] = await db.select().from(schema.academyItems)
+    .where(eq(schema.academyItems.id, id)).limit(1);
+  return row ?? null;
 }
 
 export async function updateAcademyItem(id: string, patch: Partial<InsertAcademyItem>): Promise<AcademyItem | null> {

--- a/server/services/academy-service.ts
+++ b/server/services/academy-service.ts
@@ -241,16 +241,28 @@ export async function listAcademyTenants(academyId: string): Promise<AcademyTena
     .where(eq(schema.academyTenants.academyId, academyId));
 }
 
-export async function addAcademyTenant(academyId: string, tenantId: string): Promise<schema.AcademyTenant> {
-  const [row] = await db.insert(schema.academyTenants)
+export interface AddAcademyTenantResult {
+  row: schema.AcademyTenant | null;
+  created: boolean;
+}
+
+export async function addAcademyTenant(academyId: string, tenantId: string): Promise<AddAcademyTenantResult> {
+  const [inserted] = await db.insert(schema.academyTenants)
     .values({ academyId, tenantId })
     .onConflictDoNothing()
     .returning();
-  if (row) return row;
+  if (inserted) return { row: inserted, created: true };
   const [existing] = await db.select().from(schema.academyTenants)
     .where(and(eq(schema.academyTenants.academyId, academyId), eq(schema.academyTenants.tenantId, tenantId)))
     .limit(1);
-  return existing;
+  return { row: existing ?? null, created: false };
+}
+
+export async function listAcademyItemIds(academyId: string): Promise<string[]> {
+  const rows = await db.select({ id: schema.academyItems.id })
+    .from(schema.academyItems)
+    .where(eq(schema.academyItems.academyId, academyId));
+  return rows.map(r => r.id);
 }
 
 export async function removeAcademyTenant(academyId: string, tenantId: string): Promise<boolean> {

--- a/server/services/academy-service.ts
+++ b/server/services/academy-service.ts
@@ -1,0 +1,261 @@
+/**
+ * Academy service — DB helpers for Academies (Learning Sequences).
+ *
+ * Academies are ordered sequences of learning items. Each item is either an
+ * internal course reference or an external link (LinkedIn Learning, Coursera,
+ * etc.). Visibility + tenant sharing mirror the courses module (`courses` /
+ * `courseTenants`), so the same access rules apply.
+ */
+
+import { db } from "../db";
+import { and, eq, inArray, or, desc } from "drizzle-orm";
+import * as schema from "@shared/schema";
+import type {
+  Academy, InsertAcademy,
+  AcademyItem, InsertAcademyItem,
+  Course,
+} from "@shared/schema";
+
+export interface AcademyListOptions {
+  status?: string;
+  statuses?: string[];
+  tenantIds?: string[] | null; // null = global admin
+}
+
+export interface AcademyWithMeta extends Academy {
+  itemCount: number;
+}
+
+export interface AcademyItemHydrated extends AcademyItem {
+  course?: Pick<Course, "id" | "slug" | "title" | "summary" | "imageUrl" | "estimatedMinutes" | "status" | "visibility"> | null;
+}
+
+export interface AcademyFull extends Academy {
+  items: AcademyItemHydrated[];
+}
+
+async function visibilityFilter(opts: AcademyListOptions): Promise<any | undefined> {
+  if (opts.tenantIds === null) return undefined;
+  const tenantIds = opts.tenantIds ?? [];
+  if (tenantIds.length === 0) {
+    return eq(schema.academies.visibility, "public");
+  }
+  const sharedRows = await db.select({ academyId: schema.academyTenants.academyId })
+    .from(schema.academyTenants)
+    .where(inArray(schema.academyTenants.tenantId, tenantIds));
+  const sharedIds = sharedRows.map(r => r.academyId);
+
+  const conds: any[] = [
+    eq(schema.academies.visibility, "public"),
+    inArray(schema.academies.ownerTenantId, tenantIds),
+  ];
+  if (sharedIds.length > 0) {
+    conds.push(inArray(schema.academies.id, sharedIds));
+  }
+  return or(...conds);
+}
+
+export async function userCanViewAcademy(user: schema.User | undefined, academy: Academy): Promise<boolean> {
+  if (academy.visibility === "public") return true;
+  if (!user) return false;
+  if (user.role === "global_admin") return true;
+  if (user.tenantId && academy.ownerTenantId === user.tenantId) return true;
+  if (user.tenantId) {
+    const [shared] = await db.select().from(schema.academyTenants)
+      .where(and(eq(schema.academyTenants.academyId, academy.id), eq(schema.academyTenants.tenantId, user.tenantId)))
+      .limit(1);
+    if (shared) return true;
+  }
+  return false;
+}
+
+export function userCanManageAcademy(user: schema.User | undefined, academy: Academy): boolean {
+  if (!user) return false;
+  if (user.role === "global_admin") return true;
+  if (user.role !== "tenant_admin" && user.role !== "tenant_modeler") return false;
+  return !!user.tenantId && academy.ownerTenantId === user.tenantId;
+}
+
+async function enrichAcademyList(rows: Academy[]): Promise<AcademyWithMeta[]> {
+  if (rows.length === 0) return [];
+  const ids = rows.map(r => r.id);
+  const items = await db.select({ academyId: schema.academyItems.academyId })
+    .from(schema.academyItems)
+    .where(inArray(schema.academyItems.academyId, ids));
+  const counts = new Map<string, number>();
+  for (const i of items) counts.set(i.academyId, (counts.get(i.academyId) || 0) + 1);
+  return rows.map(a => ({ ...a, itemCount: counts.get(a.id) || 0 }));
+}
+
+export async function listAcademies(opts: AcademyListOptions = {}): Promise<AcademyWithMeta[]> {
+  const conds: any[] = [];
+  if (opts.statuses && opts.statuses.length > 0) {
+    conds.push(inArray(schema.academies.status, opts.statuses as any));
+  } else if (opts.status) {
+    conds.push(eq(schema.academies.status, opts.status as any));
+  }
+  const vis = await visibilityFilter(opts);
+  if (vis) conds.push(vis);
+  const rows = await db.select().from(schema.academies)
+    .where(conds.length ? and(...conds) : undefined)
+    .orderBy(desc(schema.academies.updatedAt));
+  return enrichAcademyList(rows);
+}
+
+export async function listAcademiesOwnedBy(
+  tenantIds: string[] | null,
+  statuses: string[],
+): Promise<AcademyWithMeta[]> {
+  const conds: any[] = [inArray(schema.academies.status, statuses as any)];
+  if (tenantIds !== null) {
+    if (tenantIds.length === 0) return [];
+    conds.push(inArray(schema.academies.ownerTenantId, tenantIds));
+  }
+  const rows = await db.select().from(schema.academies)
+    .where(and(...conds))
+    .orderBy(desc(schema.academies.updatedAt));
+  return enrichAcademyList(rows);
+}
+
+export async function getAcademyById(id: string): Promise<Academy | null> {
+  const [row] = await db.select().from(schema.academies).where(eq(schema.academies.id, id)).limit(1);
+  return row ?? null;
+}
+
+export async function getAcademyFull(idOrSlug: string): Promise<AcademyFull | null> {
+  const [academy] = await db.select().from(schema.academies)
+    .where(or(eq(schema.academies.id, idOrSlug), eq(schema.academies.slug, idOrSlug)))
+    .limit(1);
+  if (!academy) return null;
+  const items = await db.select().from(schema.academyItems)
+    .where(eq(schema.academyItems.academyId, academy.id))
+    .orderBy(schema.academyItems.order);
+
+  const courseIds = items.map(i => i.courseId).filter((id): id is string => !!id);
+  const courseRows = courseIds.length > 0
+    ? await db.select({
+        id: schema.courses.id,
+        slug: schema.courses.slug,
+        title: schema.courses.title,
+        summary: schema.courses.summary,
+        imageUrl: schema.courses.imageUrl,
+        estimatedMinutes: schema.courses.estimatedMinutes,
+        status: schema.courses.status,
+        visibility: schema.courses.visibility,
+      })
+        .from(schema.courses)
+        .where(inArray(schema.courses.id, courseIds))
+    : [];
+  const courseById = new Map(courseRows.map(c => [c.id, c]));
+
+  const hydrated: AcademyItemHydrated[] = items.map(i => ({
+    ...i,
+    course: i.courseId ? (courseById.get(i.courseId) ?? null) : null,
+  }));
+
+  return { ...academy, items: hydrated };
+}
+
+export async function createAcademy(data: InsertAcademy): Promise<Academy> {
+  const [row] = await db.insert(schema.academies).values(data as any).returning();
+  return row;
+}
+
+export async function updateAcademy(id: string, patch: Partial<InsertAcademy>): Promise<Academy | null> {
+  const [row] = await db.update(schema.academies)
+    .set({ ...patch, updatedAt: new Date() } as any)
+    .where(eq(schema.academies.id, id)).returning();
+  return row ?? null;
+}
+
+export async function archiveAcademy(id: string): Promise<Academy | null> {
+  const [row] = await db.update(schema.academies)
+    .set({ status: "archived", updatedAt: new Date() } as any)
+    .where(eq(schema.academies.id, id)).returning();
+  return row ?? null;
+}
+
+export async function deleteAcademy(id: string): Promise<void> {
+  await db.delete(schema.academies).where(eq(schema.academies.id, id));
+}
+
+// ----- Items -----
+export async function createAcademyItem(data: InsertAcademyItem): Promise<AcademyItem> {
+  const [row] = await db.insert(schema.academyItems).values(data as any).returning();
+  return row;
+}
+
+export async function updateAcademyItem(id: string, patch: Partial<InsertAcademyItem>): Promise<AcademyItem | null> {
+  const [row] = await db.update(schema.academyItems).set(patch as any)
+    .where(eq(schema.academyItems.id, id)).returning();
+  return row ?? null;
+}
+
+export async function deleteAcademyItem(id: string): Promise<void> {
+  await db.delete(schema.academyItems).where(eq(schema.academyItems.id, id));
+}
+
+export async function getAcademyForItem(itemId: string): Promise<Academy | null> {
+  const [row] = await db.select({ academy: schema.academies })
+    .from(schema.academyItems)
+    .innerJoin(schema.academies, eq(schema.academyItems.academyId, schema.academies.id))
+    .where(eq(schema.academyItems.id, itemId))
+    .limit(1);
+  return (row as any)?.academy ?? null;
+}
+
+export async function reorderAcademyItems(
+  academyId: string,
+  orderedIds: string[],
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    for (let i = 0; i < orderedIds.length; i++) {
+      await tx.update(schema.academyItems)
+        .set({ order: i })
+        .where(and(
+          eq(schema.academyItems.id, orderedIds[i]),
+          eq(schema.academyItems.academyId, academyId),
+        ));
+    }
+  });
+}
+
+// ----- Tenant share -----
+export interface AcademyTenantShare {
+  id: string;
+  tenantId: string;
+  tenantName: string;
+  createdAt: Date;
+}
+
+export async function listAcademyTenants(academyId: string): Promise<AcademyTenantShare[]> {
+  return await db
+    .select({
+      id: schema.academyTenants.id,
+      tenantId: schema.academyTenants.tenantId,
+      tenantName: schema.tenants.name,
+      createdAt: schema.academyTenants.createdAt,
+    })
+    .from(schema.academyTenants)
+    .innerJoin(schema.tenants, eq(schema.academyTenants.tenantId, schema.tenants.id))
+    .where(eq(schema.academyTenants.academyId, academyId));
+}
+
+export async function addAcademyTenant(academyId: string, tenantId: string): Promise<schema.AcademyTenant> {
+  const [row] = await db.insert(schema.academyTenants)
+    .values({ academyId, tenantId })
+    .onConflictDoNothing()
+    .returning();
+  if (row) return row;
+  const [existing] = await db.select().from(schema.academyTenants)
+    .where(and(eq(schema.academyTenants.academyId, academyId), eq(schema.academyTenants.tenantId, tenantId)))
+    .limit(1);
+  return existing;
+}
+
+export async function removeAcademyTenant(academyId: string, tenantId: string): Promise<boolean> {
+  const rows = await db.delete(schema.academyTenants)
+    .where(and(eq(schema.academyTenants.academyId, academyId), eq(schema.academyTenants.tenantId, tenantId)))
+    .returning();
+  return rows.length > 0;
+}

--- a/server/services/course-service.ts
+++ b/server/services/course-service.ts
@@ -221,6 +221,48 @@ export async function deleteCourse(id: string): Promise<void> {
   await db.delete(schema.courses).where(eq(schema.courses.id, id));
 }
 
+// ----- Course ↔ tenant share (manages course_tenants junction) -----
+export interface CourseTenantShare {
+  id: string;
+  tenantId: string;
+  tenantName: string;
+  createdAt: Date;
+}
+
+export async function listCourseTenants(courseId: string): Promise<CourseTenantShare[]> {
+  const rows = await db
+    .select({
+      id: schema.courseTenants.id,
+      tenantId: schema.courseTenants.tenantId,
+      tenantName: schema.tenants.name,
+      createdAt: schema.courseTenants.createdAt,
+    })
+    .from(schema.courseTenants)
+    .innerJoin(schema.tenants, eq(schema.courseTenants.tenantId, schema.tenants.id))
+    .where(eq(schema.courseTenants.courseId, courseId));
+  return rows;
+}
+
+export async function addCourseTenant(courseId: string, tenantId: string): Promise<schema.CourseTenant> {
+  const [row] = await db.insert(schema.courseTenants)
+    .values({ courseId, tenantId })
+    .onConflictDoNothing()
+    .returning();
+  if (row) return row;
+  // Already existed — fetch the existing row to keep the response shape consistent
+  const [existing] = await db.select().from(schema.courseTenants)
+    .where(and(eq(schema.courseTenants.courseId, courseId), eq(schema.courseTenants.tenantId, tenantId)))
+    .limit(1);
+  return existing;
+}
+
+export async function removeCourseTenant(courseId: string, tenantId: string): Promise<boolean> {
+  const rows = await db.delete(schema.courseTenants)
+    .where(and(eq(schema.courseTenants.courseId, courseId), eq(schema.courseTenants.tenantId, tenantId)))
+    .returning();
+  return rows.length > 0;
+}
+
 export async function archiveCourse(id: string): Promise<Course | null> {
   const [row] = await db.update(schema.courses)
     .set({ status: "archived", updatedAt: new Date() } as any)

--- a/server/services/course-service.ts
+++ b/server/services/course-service.ts
@@ -243,17 +243,23 @@ export async function listCourseTenants(courseId: string): Promise<CourseTenantS
   return rows;
 }
 
-export async function addCourseTenant(courseId: string, tenantId: string): Promise<schema.CourseTenant> {
-  const [row] = await db.insert(schema.courseTenants)
+export interface AddCourseTenantResult {
+  row: schema.CourseTenant | null;
+  created: boolean;
+}
+
+export async function addCourseTenant(courseId: string, tenantId: string): Promise<AddCourseTenantResult> {
+  const [inserted] = await db.insert(schema.courseTenants)
     .values({ courseId, tenantId })
     .onConflictDoNothing()
     .returning();
-  if (row) return row;
-  // Already existed — fetch the existing row to keep the response shape consistent
+  if (inserted) return { row: inserted, created: true };
+  // Already existed — fetch the existing row. Could still be missing if a
+  // concurrent delete races, so the caller must handle null.
   const [existing] = await db.select().from(schema.courseTenants)
     .where(and(eq(schema.courseTenants.courseId, courseId), eq(schema.courseTenants.tenantId, tenantId)))
     .limit(1);
-  return existing;
+  return { row: existing ?? null, created: false };
 }
 
 export async function removeCourseTenant(courseId: string, tenantId: string): Promise<boolean> {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1638,3 +1638,107 @@ export type ScormPackage = typeof scormPackages.$inferSelect;
 export type InsertScormPackage = z.infer<typeof insertScormPackageSchema>;
 export type CourseTenant = typeof courseTenants.$inferSelect;
 export type InsertCourseTenant = z.infer<typeof insertCourseTenantSchema>;
+
+// ========== ACADEMIES (Learning Sequences) ==========
+//
+// An academy is an ordered sequence of learning items. Each item is either a
+// reference to an internal `course` (Orion-authored content) or an external
+// link (LinkedIn Learning, Coursera, YouTube, etc.). Visibility & tenant
+// sharing follow the same pattern as `courses` / `courseTenants`.
+
+export const ACADEMY_STATUSES = ['draft', 'published', 'archived'] as const;
+export const ACADEMY_VISIBILITIES = ['public', 'private'] as const;
+export const ACADEMY_ITEM_TYPES = ['course', 'external'] as const;
+export const ACADEMY_EXTERNAL_PROVIDERS = [
+  'linkedin_learning',
+  'coursera',
+  'pluralsight',
+  'youtube',
+  'udemy',
+  'edx',
+  'other',
+] as const;
+
+export type AcademyStatus = typeof ACADEMY_STATUSES[number];
+export type AcademyVisibility = typeof ACADEMY_VISIBILITIES[number];
+export type AcademyItemType = typeof ACADEMY_ITEM_TYPES[number];
+export type AcademyExternalProvider = typeof ACADEMY_EXTERNAL_PROVIDERS[number];
+
+export const academies = pgTable("academies", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  slug: text("slug").notNull().unique(),
+  title: text("title").notNull(),
+  description: text("description").notNull().default(""),
+  summary: text("summary"),
+  imageUrl: text("image_url"),
+  estimatedMinutes: integer("estimated_minutes"),
+  status: text("status").notNull().$type<AcademyStatus>().default("draft"),
+  visibility: text("visibility").notNull().$type<AcademyVisibility>().default("private"),
+  ownerTenantId: varchar("owner_tenant_id"),
+  createdBy: varchar("created_by").references(() => users.id, { onDelete: "set null" }),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+}, (table) => ({
+  ownerTenantIdx: index("idx_academies_owner_tenant").on(table.ownerTenantId),
+  statusVisibilityIdx: index("idx_academies_status_visibility").on(table.status, table.visibility),
+}));
+
+// Junction table for sharing private academies with specific tenants.
+export const academyTenants = pgTable("academy_tenants", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  academyId: varchar("academy_id").notNull().references(() => academies.id, { onDelete: "cascade" }),
+  tenantId: varchar("tenant_id").notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (table) => ({
+  uniq: unique().on(table.academyId, table.tenantId),
+  academyIdx: index("idx_academy_tenants_academy").on(table.academyId),
+  tenantIdx: index("idx_academy_tenants_tenant").on(table.tenantId),
+}));
+
+// An academy item is one entry in the sequence. `itemType` is either:
+//  - 'course'   → courseId references a row in `courses`
+//  - 'external' → externalProvider/title/url/etc. populated, courseId null
+export const academyItems = pgTable("academy_items", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  academyId: varchar("academy_id").notNull().references(() => academies.id, { onDelete: "cascade" }),
+  order: integer("order").notNull().default(0),
+  itemType: text("item_type").notNull().$type<AcademyItemType>(),
+  courseId: varchar("course_id").references(() => courses.id, { onDelete: "set null" }),
+  externalProvider: text("external_provider").$type<AcademyExternalProvider>(),
+  externalTitle: text("external_title"),
+  externalUrl: text("external_url"),
+  externalDurationMinutes: integer("external_duration_minutes"),
+  externalDescription: text("external_description"),
+  required: boolean("required").notNull().default(true),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+}, (table) => ({
+  academyIdx: index("idx_academy_items_academy").on(table.academyId),
+  courseIdx: index("idx_academy_items_course").on(table.courseId),
+}));
+
+export const insertAcademySchema = createInsertSchema(academies).omit({
+  id: true, createdAt: true, updatedAt: true,
+}).extend({
+  slug: z.string().min(1).max(100).regex(/^[a-z0-9-]+$/, "Slug must be lowercase letters, numbers, and hyphens"),
+  title: z.string().min(1).max(255),
+  description: z.string().default(""),
+});
+
+export const insertAcademyItemSchema = createInsertSchema(academyItems).omit({
+  id: true, createdAt: true,
+}).extend({
+  itemType: z.enum(ACADEMY_ITEM_TYPES),
+  externalProvider: z.enum(ACADEMY_EXTERNAL_PROVIDERS).nullable().optional(),
+  externalUrl: z.string().url().nullable().optional(),
+});
+
+export const insertAcademyTenantSchema = createInsertSchema(academyTenants).omit({
+  id: true, createdAt: true,
+});
+
+export type Academy = typeof academies.$inferSelect;
+export type InsertAcademy = z.infer<typeof insertAcademySchema>;
+export type AcademyItem = typeof academyItems.$inferSelect;
+export type InsertAcademyItem = z.infer<typeof insertAcademyItemSchema>;
+export type AcademyTenant = typeof academyTenants.$inferSelect;
+export type InsertAcademyTenant = z.infer<typeof insertAcademyTenantSchema>;


### PR DESCRIPTION
- Course admin: hide archived courses by default; new "Show archived"
  toggle exposes them. Archived list driven by ?includeArchived=true
  on /api/courses?manageable=true.
- Course admin: replace plain image-URL input with the same
  ObjectUploader used by models. Adds PUT /api/courses/:id/image
  that ACLs the upload public and stamps the normalized path.
- Course admin: tenant-share dialog for private courses, backed by
  GET/POST/DELETE /api/courses/:id/tenants and the existing
  course_tenants junction. Global-admin gated to match models.
- Academies: new "learning sequences" feature. Adds academies,
  academy_items (course | external), and academy_tenants tables.
  Items can be Orion courses or external links (LinkedIn Learning,
  Coursera, Pluralsight, YouTube, Udemy, edX, other).
- Academies API: CRUD, item add/edit/delete/reorder, tenant share,
  hero-image upload — visibility filter mirrors courses
  (public + ownerTenantId + academy_tenants junction).
- Admin UI: AcademyManagement with archived toggle, builder,
  ordered item list (move up/down), and tenant-share dialog.
- Learner UI: /academies catalog and /academies/:slug detail page
  that links into Orion courses or out to external providers.

Schema changes are additive; run `npm run db:push` to apply.