### PR TITLE
Add catalog search and filtering to the courses page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This changelog documents new features, improvements, and fixes in Orion. Updates
 
 ## May 2026 — Version 2.1
 
+### May 15, 2026 — Course Catalog Filters & Search
+
+**New Features**
+- **Catalog search & filtering** on `/courses`: keyword search across course title, summary, and description; multi-select tag chips; duration buckets (under 30 min, 30–60 min, over 60 min); and a per-learner completion-status filter (not started / in progress / completed). A live result count and one-click "Clear filters" keep the catalog easy to scan as it grows.
+
+**Notes**
+- Completes the last open item in the Learning Courses MVP follow-ups. The assessment-driven recommendation surface (Results page + "Suggested for you") and certificate PDF generation were already shipped and are now reflected as complete in the backlog.
+
 ### May 2, 2026 - Galaxy Client Portal API
 
 **New Features**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This changelog documents new features, improvements, and fixes in Orion. Updates
 
 ## May 2026 — Version 2.1
 
+### May 15, 2026 — Mobile-Friendly Assessment Navigation
+
+**Improvements**
+- Assessment wizard mobile polish for the live-event critical path: on small screens the Previous/Next controls are now a sticky bottom navigation bar with large, full-width tap targets and safe-area padding for notched devices, so attendees taking an assessment on a phone always have the controls in reach. Desktop layout is unchanged.
+
 ### May 15, 2026 — Course Catalog Filters & Search
 
 **New Features**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md
+
+Guidance for Claude when working in this repository.
+
+## Pull request workflow (permanent instruction)
+
+For **every** pull request created during work in this repository:
+
+1. **Subscribe** to the PR's activity (`subscribe_pr_activity`) so CI
+   failures and review comments are delivered into the session.
+2. **Review** the PR for comments — both review (inline) comments and
+   general PR comments — and **fix** the issues they raise.
+3. **Reply to each comment that is fixed**, attaching the reply to that
+   specific comment so the resolution is traceable.
+4. Keep CI green: investigate failures and push fixes until checks pass.
+
+This applies to PRs you create and to existing PRs you are asked to work on.

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -388,10 +388,10 @@ The MVP slice (catalog, player, authoring, quizzes, attestations, enrollment tra
 
 1. **SCORM 1.2 / 2004 import** — accept `.zip` uploads, parse `imsmanifest.xml`, store package in object storage, serve runtime that wires `cmi.*` → `lessonProgress.data`. Endpoints stubbed at `POST /api/scorm/import` (501).
 2. **SCORM export** — generate a SCORM zip from a course's structure. Stub at `GET /api/courses/:id/scorm/export` (501).
-3. **Certificate PDF generation** — when an enrollment completes and `certificateEnabled` is true, render a branded PDF and store its URL in `certificateUrl`.
+3. ~~**Certificate PDF generation**~~ — **DONE.** `server/services/certificate-pdf.ts` renders a branded PDF via `pdf-lib`; `maybeIssueCertificate` stamps `certificateUrl` on enrollment completion. A `POST /api/courses/:id/certificate` re-issue endpoint exists for backfill.
 4. **Attestation reminders/expirations** — scheduled email job (SendGrid) to nudge or re-collect expired attestations.
-5. **Assessment → course recommendation surface** — `assessment_course_links` is wired with score thresholds; need a UI on the Results page that lists recommended courses based on weak dimensions, plus a "Suggested for you" card on `/courses`.
-6. **Catalog filters/search** — by tag, completion status, duration, level.
+5. ~~**Assessment → course recommendation surface**~~ — **DONE.** Recommended-courses card renders on the Results page (driven by weak dimension scores) and a "Suggested for you" section on `/courses`, backed by `/api/assessments/:id/recommended-courses` and `/api/me/recommended-courses`.
+6. ~~**Catalog filters/search**~~ — **DONE.** `/courses` supports keyword search (title/summary/description), tag chips, duration buckets (under 30 / 30–60 / over 60 min), and per-learner completion status (not started / in progress / completed). "Level" filter omitted — no `level` field exists on the `courses` schema; defer until a level taxonomy is scoped.
 7. **Video transcoding/hosting** — currently stores raw URLs; consider Mux or Cloudflare Stream for adaptive playback.
 8. **xAPI (Tin Can) statements** — emit statements for richer learning analytics.
 

--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -309,13 +309,13 @@ Complete branding customization:
 
 ### 12. Mobile Applications
 
-**Status:** Not Started
+**Status:** Not Started (PWA explicitly deferred — mobile-friendly polish only)
 **Priority:** Low
 **Effort:** 8-12 weeks
 
-- Progressive Web App (PWA) first
+- Progressive Web App (PWA) — **deferred by product decision.** A PWA implementation (manifest, service worker, install prompt, offline resilience) was prototyped on May 15, 2026 but rolled back; the requirement is mobile-friendliness, not an installable/offline app. Revisit only if an installable/offline experience becomes a confirmed requirement.
+- Mobile-friendly responsive polish: in progress incrementally per surface (assessment wizard sticky bottom nav + large tap targets shipped May 15, 2026). See **UX Enhancements → Responsive Design**.
 - iOS and Android native apps (future)
-- Offline assessment capability
 
 ---
 

--- a/client/src/pages/Assessment.tsx
+++ b/client/src/pages/Assessment.tsx
@@ -613,24 +613,28 @@ export default function Assessment() {
             </Card>
           )}
 
-          <div className="flex flex-wrap justify-between gap-3 mt-6 sm:mt-8">
+          <div className="sticky bottom-0 z-10 -mx-3 mt-6 flex justify-between gap-3 border-t bg-background/95 px-3 py-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] backdrop-blur supports-[backdrop-filter]:bg-background/80 sm:static sm:mx-0 sm:mt-8 sm:flex-wrap sm:border-0 sm:bg-transparent sm:p-0 sm:pb-0 sm:backdrop-blur-none">
             <Button
               variant="outline"
+              size="lg"
               onClick={handlePrevious}
               disabled={!canGoPrev}
               data-testid="button-previous"
+              className="flex-1 sm:flex-none sm:h-10"
             >
               <ChevronLeft className="mr-1 sm:mr-2 h-4 w-4" />
               <span className="hidden sm:inline">{t('common.previous')}</span>
               <span className="sm:hidden">{t('common.back')}</span>
             </Button>
             <Button
+              size="lg"
               onClick={handleNext}
               disabled={
                 calculateResults.isPending ||
                 (!isLast && !isCurrentAnswered)
               }
               data-testid="button-next"
+              className="flex-1 sm:flex-none sm:h-10"
             >
               {calculateResults.isPending
                 ? t('common.calculating')

--- a/client/src/pages/Courses.tsx
+++ b/client/src/pages/Courses.tsx
@@ -164,12 +164,7 @@ export default function Courses() {
         if (!haystack.includes(q)) return false;
       }
       if (selectedTagIds.size > 0) {
-        const courseTagIds = new Set(c.tags.map(t => t.id));
-        let hasAny = false;
-        for (const id of selectedTagIds) {
-          if (courseTagIds.has(id)) { hasAny = true; break; }
-        }
-        if (!hasAny) return false;
+        if (!c.tags.some(t => selectedTagIds.has(t.id))) return false;
       }
       if (duration !== "any") {
         const m = c.estimatedMinutes;

--- a/client/src/pages/Courses.tsx
+++ b/client/src/pages/Courses.tsx
@@ -1,13 +1,22 @@
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Helmet } from "react-helmet-async";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
-import { BookOpen, Clock, Users, Sparkles } from "lucide-react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { BookOpen, Clock, Users, Sparkles, Search, X } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
-import type { Course, CourseTag } from "@shared/schema";
+import type { Course, CourseTag, CourseEnrollment } from "@shared/schema";
 
 interface CourseListItem extends Course {
   moduleCount: number;
@@ -28,6 +37,13 @@ interface MyRecommendationsResponse {
   assessmentId: string | null;
   courses: RecommendedCourse[];
 }
+
+interface EnrollmentWithCourse extends CourseEnrollment {
+  course: Course;
+}
+
+type DurationFilter = "any" | "short" | "medium" | "long";
+type StatusFilter = "any" | "not_started" | "in_progress" | "completed";
 
 function CourseCard({ course, testIdPrefix = "card-course" }: { course: CourseListItem; testIdPrefix?: string }) {
   return (
@@ -91,7 +107,84 @@ export default function Courses() {
     enabled: !!user,
   });
 
+  const { data: myEnrollments } = useQuery<EnrollmentWithCourse[]>({
+    queryKey: ["/api/me/courses"],
+    enabled: !!user,
+  });
+
   const suggested = recommended?.courses ?? [];
+
+  const [search, setSearch] = useState("");
+  const [selectedTagIds, setSelectedTagIds] = useState<Set<string>>(new Set());
+  const [duration, setDuration] = useState<DurationFilter>("any");
+  const [status, setStatus] = useState<StatusFilter>("any");
+
+  // courseId -> learner's bucketed completion status
+  const enrollmentStatusByCourse = useMemo(() => {
+    const map = new Map<string, StatusFilter>();
+    for (const e of myEnrollments ?? []) {
+      map.set(e.courseId, e.status === "completed" ? "completed" : "in_progress");
+    }
+    return map;
+  }, [myEnrollments]);
+
+  // Unique tags across the catalog, for the tag filter chips
+  const allTags = useMemo(() => {
+    const byId = new Map<string, CourseTag>();
+    for (const c of courses ?? []) {
+      for (const t of c.tags) byId.set(t.id, t);
+    }
+    return Array.from(byId.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [courses]);
+
+  const hasActiveFilters =
+    search.trim() !== "" || selectedTagIds.size > 0 || duration !== "any" || status !== "any";
+
+  const toggleTag = (id: string) => {
+    setSelectedTagIds(prev => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const clearFilters = () => {
+    setSearch("");
+    setSelectedTagIds(new Set());
+    setDuration("any");
+    setStatus("any");
+  };
+
+  const filteredCourses = useMemo(() => {
+    if (!courses) return [];
+    const q = search.trim().toLowerCase();
+    return courses.filter(c => {
+      if (q) {
+        const haystack = `${c.title} ${c.summary ?? ""} ${c.description ?? ""}`.toLowerCase();
+        if (!haystack.includes(q)) return false;
+      }
+      if (selectedTagIds.size > 0) {
+        const courseTagIds = new Set(c.tags.map(t => t.id));
+        let hasAny = false;
+        for (const id of selectedTagIds) {
+          if (courseTagIds.has(id)) { hasAny = true; break; }
+        }
+        if (!hasAny) return false;
+      }
+      if (duration !== "any") {
+        const m = c.estimatedMinutes;
+        if (m == null) return false;
+        if (duration === "short" && m >= 30) return false;
+        if (duration === "medium" && (m < 30 || m > 60)) return false;
+        if (duration === "long" && m <= 60) return false;
+      }
+      if (status !== "any") {
+        const courseStatus = enrollmentStatusByCourse.get(c.id) ?? "not_started";
+        if (courseStatus !== status) return false;
+      }
+      return true;
+    });
+  }, [courses, search, selectedTagIds, duration, status, enrollmentStatusByCourse]);
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-6xl">
@@ -149,11 +242,97 @@ export default function Courses() {
           {suggested.length > 0 && (
             <h2 className="text-xl font-semibold mb-4" data-testid="text-all-courses-heading">All courses</h2>
           )}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {courses.map(c => (
-              <CourseCard key={c.id} course={c} />
-            ))}
+
+          <div className="mb-6 space-y-4" data-testid="course-filters">
+            <div className="flex flex-col sm:flex-row gap-3">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  placeholder="Search courses..."
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="pl-10"
+                  data-testid="input-course-search"
+                />
+              </div>
+              <Select value={duration} onValueChange={(v) => setDuration(v as DurationFilter)}>
+                <SelectTrigger className="w-full sm:w-44" data-testid="select-duration">
+                  <SelectValue placeholder="Duration" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="any">Any duration</SelectItem>
+                  <SelectItem value="short">Under 30 min</SelectItem>
+                  <SelectItem value="medium">30–60 min</SelectItem>
+                  <SelectItem value="long">Over 60 min</SelectItem>
+                </SelectContent>
+              </Select>
+              {user && (
+                <Select value={status} onValueChange={(v) => setStatus(v as StatusFilter)}>
+                  <SelectTrigger className="w-full sm:w-44" data-testid="select-status">
+                    <SelectValue placeholder="Status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="any">Any status</SelectItem>
+                    <SelectItem value="not_started">Not started</SelectItem>
+                    <SelectItem value="in_progress">In progress</SelectItem>
+                    <SelectItem value="completed">Completed</SelectItem>
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+
+            {allTags.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2" data-testid="filter-tags">
+                {allTags.map(t => {
+                  const active = selectedTagIds.has(t.id);
+                  return (
+                    <button
+                      key={t.id}
+                      type="button"
+                      onClick={() => toggleTag(t.id)}
+                      data-testid={`filter-tag-${t.id}`}
+                      aria-pressed={active}
+                    >
+                      <Badge variant={active ? "default" : "outline"} className="cursor-pointer">
+                        {t.name}
+                      </Badge>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {hasActiveFilters && (
+              <div className="flex items-center gap-3 text-sm text-muted-foreground">
+                <span data-testid="text-filter-count">
+                  {filteredCourses.length} of {courses.length} course{courses.length === 1 ? "" : "s"}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-7 px-2"
+                  onClick={clearFilters}
+                  data-testid="button-clear-filters"
+                >
+                  <X className="h-3.5 w-3.5 mr-1" /> Clear filters
+                </Button>
+              </div>
+            )}
           </div>
+
+          {filteredCourses.length === 0 ? (
+            <Card>
+              <CardContent className="pt-6 text-center text-muted-foreground" data-testid="text-no-matching-courses">
+                No courses match your filters.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {filteredCourses.map(c => (
+                <CourseCard key={c.id} course={c} />
+              ))}
+            </div>
+          )}
         </>
       )}
     </div>

--- a/client/src/pages/Courses.tsx
+++ b/client/src/pages/Courses.tsx
@@ -107,7 +107,7 @@ export default function Courses() {
     enabled: !!user,
   });
 
-  const { data: myEnrollments } = useQuery<EnrollmentWithCourse[]>({
+  const { data: myEnrollments, isLoading: enrollmentsLoading } = useQuery<EnrollmentWithCourse[]>({
     queryKey: ["/api/me/courses"],
     enabled: !!user,
   });
@@ -122,8 +122,18 @@ export default function Courses() {
   // courseId -> learner's bucketed completion status
   const enrollmentStatusByCourse = useMemo(() => {
     const map = new Map<string, StatusFilter>();
+    // Enrollment enum is ['enrolled','in_progress','completed','expired'].
+    // Map to learner-facing buckets: only an active "in_progress" counts as
+    // in progress; "enrolled" (never opened) and "expired" read as not
+    // started so they align with the filter's "Not started" option.
     for (const e of myEnrollments ?? []) {
-      map.set(e.courseId, e.status === "completed" ? "completed" : "in_progress");
+      const bucket: StatusFilter =
+        e.status === "completed"
+          ? "completed"
+          : e.status === "in_progress"
+            ? "in_progress"
+            : "not_started";
+      map.set(e.courseId, bucket);
     }
     return map;
   }, [myEnrollments]);
@@ -143,7 +153,11 @@ export default function Courses() {
   const toggleTag = (id: string) => {
     setSelectedTagIds(prev => {
       const next = new Set(prev);
-      next.has(id) ? next.delete(id) : next.add(id);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
       return next;
     });
   };
@@ -173,13 +187,16 @@ export default function Courses() {
         if (duration === "medium" && (m < 30 || m > 60)) return false;
         if (duration === "long" && m <= 60) return false;
       }
-      if (status !== "any") {
+      // Don't apply the status filter until enrollments have loaded,
+      // otherwise everything reads as "not started" for a logged-in user
+      // and the empty state flashes before the data resolves.
+      if (status !== "any" && !enrollmentsLoading) {
         const courseStatus = enrollmentStatusByCourse.get(c.id) ?? "not_started";
         if (courseStatus !== status) return false;
       }
       return true;
     });
-  }, [courses, search, selectedTagIds, duration, status, enrollmentStatusByCourse]);
+  }, [courses, search, selectedTagIds, duration, status, enrollmentStatusByCourse, enrollmentsLoading]);
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-6xl">
@@ -287,6 +304,8 @@ export default function Courses() {
                       onClick={() => toggleTag(t.id)}
                       data-testid={`filter-tag-${t.id}`}
                       aria-pressed={active}
+                      aria-label={`Filter by ${t.name}`}
+                      className="rounded-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                     >
                       <Badge variant={active ? "default" : "outline"} className="cursor-pointer">
                         {t.name}


### PR DESCRIPTION
Completes the last open Learning Courses MVP follow-up. The /courses
catalog now supports keyword search across title/summary/description,
multi-select tag chips, duration buckets, and a per-learner completion
status filter, with a live result count and clear-filters control.

The assessment-driven recommendation surface and certificate PDF
generation were already implemented; backlog and changelog updated to
reflect their completed status.

https://claude.ai/code/session_01Sxgf5VEkpV7vWeH7kVGL7a