### PR TITLE
Replace raw JSON lesson editing with visual editors for all lesson types

### DIFF
--- a/client/src/components/admin/CourseManagement.tsx
+++ b/client/src/components/admin/CourseManagement.tsx
@@ -955,7 +955,14 @@ function LessonEditorDialog({
     try { return JSON.parse(contentJson) ?? {}; } catch { return {}; }
   })();
   const patchContent = (patch: Record<string, any>) => {
-    setContentJson(JSON.stringify({ ...parsedContent, ...patch }, null, 2));
+    // Functional update: merge into the *latest* payload rather than the
+    // render-time `parsedContent` snapshot, so rapid/batched patches from
+    // different fields can't overwrite each other.
+    setContentJson(prev => {
+      let base: any;
+      try { base = JSON.parse(prev) ?? {}; } catch { base = {}; }
+      return JSON.stringify({ ...base, ...patch }, null, 2);
+    });
   };
 
   return (

--- a/client/src/components/admin/CourseManagement.tsx
+++ b/client/src/components/admin/CourseManagement.tsx
@@ -13,12 +13,14 @@ import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, D
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { DropdownMenu, DropdownMenuCheckboxItem, DropdownMenuContent, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { Plus, Edit, Trash, Users, ChevronLeft, FileText, Save, Loader2, Upload, Download, X, ChevronDown, Share2 } from "lucide-react";
+import { Plus, Edit, Trash, Users, ChevronLeft, FileText, Save, Loader2, Upload, Download, X, ChevronDown, Share2, Sparkles } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
 import { ObjectUploader } from "@/components/ObjectUploader";
 import { SlideEditor } from "@/components/admin/SlideEditor";
+import { RichTextField, MediaUrlInput, requestTts, TTS_VOICES, DEFAULT_VOICE } from "@/components/admin/editor-fields";
 import { useAuth } from "@/hooks/use-auth";
 import type { Course, CourseModule, Lesson, CourseTag, LessonType, CourseEnrollment } from "@shared/schema";
-import { normalizeSlides, type SlidesContent } from "@shared/slides";
+import { genId, normalizeSlides, courseMediaUrl, type Slide, type SlidesContent } from "@shared/slides";
 
 interface TenantShareRow {
   id: string;
@@ -947,13 +949,22 @@ function LessonEditorDialog({
     catch { return { slides: [] }; }
   })();
 
+  // All other types drive structured editors off the parsed payload, writing
+  // back through `contentJson` so save/raw-JSON editing stay in sync.
+  const parsedContent: any = (() => {
+    try { return JSON.parse(contentJson) ?? {}; } catch { return {}; }
+  })();
+  const patchContent = (patch: Record<string, any>) => {
+    setContentJson(JSON.stringify({ ...parsedContent, ...patch }, null, 2));
+  };
+
   return (
     <Dialog open onOpenChange={onClose}>
-      <DialogContent className={type === "slides" ? "max-w-4xl max-h-[90vh] overflow-y-auto" : "max-w-2xl"}>
+      <DialogContent className={`${type === "slides" ? "max-w-4xl" : "max-w-2xl"} max-h-[90vh] overflow-y-auto`}>
         <DialogHeader>
           <DialogTitle>{lesson ? "Edit lesson" : "New lesson"}</DialogTitle>
           <DialogDescription>
-            Configure the lesson's title, type, and content payload.
+            Configure the lesson's title, type, and content.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
@@ -1039,19 +1050,89 @@ function LessonEditorDialog({
               />
             </div>
           ) : (
-            <div>
-              <Label htmlFor="ld-content">Content (JSON)</Label>
-              <Textarea
-                id="ld-content"
-                rows={12}
-                value={contentJson}
-                onChange={e => setContentJson(e.target.value)}
-                className="font-mono text-xs"
-                data-testid="textarea-lesson-content"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                {contentHelpFor(type)}
-              </p>
+            <div className="space-y-3">
+              {type === "rich_text" && (
+                <div>
+                  <Label>Content</Label>
+                  <RichTextField
+                    key={lesson?.id ?? "new"}
+                    value={parsedContent.html || ""}
+                    onChange={(html) => patchContent({ html })}
+                    placeholder="Write the lesson content…"
+                    minHeight={220}
+                  />
+                </div>
+              )}
+              {type === "video" && (
+                <VideoLessonFields content={parsedContent} courseId={courseId} onPatch={patchContent} />
+              )}
+              {type === "audio" && (
+                <AudioLessonFields content={parsedContent} courseId={courseId} onPatch={patchContent} />
+              )}
+              {type === "quiz" && (
+                <QuizLessonFields content={parsedContent} onChange={(c) => setContentJson(JSON.stringify(c, null, 2))} />
+              )}
+              {type === "attestation" && (
+                <div className="space-y-3">
+                  <div>
+                    <Label htmlFor="att-statement">Attestation statement</Label>
+                    <Textarea
+                      id="att-statement"
+                      rows={4}
+                      value={parsedContent.statement || ""}
+                      onChange={e => patchContent({ statement: e.target.value })}
+                      placeholder="I attest I have read and understood this material."
+                      data-testid="input-attestation-statement"
+                    />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      Learners type their full name to sign this statement.
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <Switch
+                      id="att-typed"
+                      checked={parsedContent.requireTyped ?? true}
+                      onCheckedChange={(v) => patchContent({ requireTyped: v })}
+                      data-testid="switch-attestation-typed"
+                    />
+                    <Label htmlFor="att-typed">Require typed signature</Label>
+                  </div>
+                </div>
+              )}
+              {type === "scorm" && (
+                <div className="rounded-md border p-3 text-sm">
+                  {parsedContent.packageId ? (
+                    <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+                      <dt className="text-muted-foreground">Package</dt>
+                      <dd className="font-mono text-xs break-all">{parsedContent.packageId}</dd>
+                      <dt className="text-muted-foreground">Entry point</dt>
+                      <dd className="font-mono text-xs">{parsedContent.entryPoint}</dd>
+                      <dt className="text-muted-foreground">SCORM version</dt>
+                      <dd>{parsedContent.version}</dd>
+                    </dl>
+                  ) : (
+                    <p className="text-muted-foreground">
+                      No package yet — upload a SCORM .zip above and the lesson is wired up automatically.
+                    </p>
+                  )}
+                </div>
+              )}
+              <details>
+                <summary className="text-xs text-muted-foreground cursor-pointer select-none">
+                  Advanced: edit raw JSON
+                </summary>
+                <Textarea
+                  id="ld-content"
+                  rows={10}
+                  value={contentJson}
+                  onChange={e => setContentJson(e.target.value)}
+                  className="font-mono text-xs mt-2"
+                  data-testid="textarea-lesson-content"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  {contentHelpFor(type)}
+                </p>
+              </details>
             </div>
           )}
           <div className="flex items-center gap-2">
@@ -1071,9 +1152,291 @@ function LessonEditorDialog({
   );
 }
 
+/** URL + upload + provider + preview for `video` lessons. */
+function VideoLessonFields({ content, courseId, onPatch }: {
+  content: any;
+  courseId: string;
+  onPatch: (patch: Record<string, any>) => void;
+}) {
+  const url: string = content.videoUrl || "";
+  const isEmbed = content.provider === "youtube" || content.provider === "vimeo" ||
+    /youtube\.com|youtu\.be|vimeo\.com/.test(url);
+  return (
+    <div className="space-y-2">
+      <MediaUrlInput
+        label="Video URL (MP4) or YouTube/Vimeo link"
+        url={url}
+        onChange={(videoUrl) => onPatch({ videoUrl })}
+        fileTypes={["video/mp4", "video/webm"]}
+      />
+      <Select value={content.provider || "mp4"} onValueChange={(v) => onPatch({ provider: v })}>
+        <SelectTrigger className="w-40" data-testid="select-video-provider"><SelectValue /></SelectTrigger>
+        <SelectContent>
+          <SelectItem value="mp4">MP4 (hosted)</SelectItem>
+          <SelectItem value="youtube">YouTube</SelectItem>
+          <SelectItem value="vimeo">Vimeo</SelectItem>
+        </SelectContent>
+      </Select>
+      <div>
+        <Label className="text-xs">Description (optional, shown above the player)</Label>
+        <Input
+          value={content.description || ""}
+          onChange={(e) => onPatch({ description: e.target.value })}
+          data-testid="input-video-description"
+        />
+      </div>
+      {url && !isEmbed && (
+        <video src={courseMediaUrl(courseId, url)} controls className="w-full max-h-64 rounded-md border" />
+      )}
+      {url && isEmbed && (
+        <p className="text-xs text-muted-foreground">Embedded player — learners see the YouTube/Vimeo player.</p>
+      )}
+    </div>
+  );
+}
+
+/** URL + upload + TTS generation + preview for `audio` lessons. */
+function AudioLessonFields({ content, courseId, onPatch }: {
+  content: any;
+  courseId: string;
+  onPatch: (patch: Record<string, any>) => void;
+}) {
+  const { toast } = useToast();
+  const [generating, setGenerating] = useState(false);
+  const url: string = content.audioUrl || "";
+
+  const generate = async () => {
+    const text = (content.transcript || "").trim();
+    if (!text) {
+      toast({ title: "Add a script first", description: "Type the words to be narrated, then generate.", variant: "destructive" });
+      return;
+    }
+    setGenerating(true);
+    try {
+      const data = await requestTts(courseId, text, content.voice || DEFAULT_VOICE);
+      onPatch({ audioUrl: data.audioUrl, voice: data.voice });
+      toast({ title: "Audio generated" });
+    } catch (err: any) {
+      toast({ title: "TTS failed", description: err.message, variant: "destructive" });
+    } finally {
+      setGenerating(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <MediaUrlInput
+        label="Audio URL (MP3/WAV) or upload"
+        url={url}
+        onChange={(audioUrl) => onPatch({ audioUrl })}
+        fileTypes={["audio/mpeg", "audio/mp3", "audio/wav", "audio/webm", "audio/ogg", "audio/m4a", "audio/mp4"]}
+      />
+      {url && <audio src={courseMediaUrl(courseId, url)} controls className="w-full" />}
+      <div>
+        <Label className="text-xs">Description (optional, shown above the player)</Label>
+        <Input
+          value={content.description || ""}
+          onChange={(e) => onPatch({ description: e.target.value })}
+          data-testid="input-audio-description"
+        />
+      </div>
+      <div className="rounded-md border p-3 space-y-2">
+        <Label className="text-xs font-medium">Or generate the audio from a script (machine voice)</Label>
+        <Textarea
+          rows={3}
+          value={content.transcript || ""}
+          onChange={(e) => onPatch({ transcript: e.target.value })}
+          placeholder="Type the words to be narrated…"
+          data-testid="input-audio-script"
+        />
+        <div className="flex items-center gap-2">
+          <Select value={content.voice || DEFAULT_VOICE} onValueChange={(v) => onPatch({ voice: v })}>
+            <SelectTrigger className="w-56" data-testid="select-audio-voice"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              {TTS_VOICES.map((v) => <SelectItem key={v.id} value={v.id}>{v.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+          <Button type="button" variant="outline" size="sm" onClick={generate} disabled={generating} data-testid="button-generate-audio">
+            {generating ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Sparkles className="h-4 w-4 mr-2" />}
+            Generate audio
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Normalize the freeform quiz payload into a single editable shape. Accepts
+ * both naming conventions the platform supports (`options`/`answers`,
+ * `correctIds`/`correctAnswerIds`/`correctAnswerId`) — the same ones the
+ * server-side grader in course-service understands.
+ */
+function normalizeQuizContent(raw: any): { passingScore: number; questions: any[] } {
+  const questions = Array.isArray(raw?.questions) ? raw.questions : [];
+  return {
+    passingScore: typeof raw?.passingScore === "number" ? raw.passingScore : 70,
+    questions: questions.map((q: any, i: number) => {
+      const choices = Array.isArray(q?.answers) ? q.answers : Array.isArray(q?.options) ? q.options : [];
+      const answers = choices.map((a: any, j: number) => ({ ...a, id: a?.id || `a${i + 1}_${j + 1}`, text: a?.text ?? "" }));
+      const multi = q?.correctIds ?? q?.correctAnswerIds;
+      const correctIds: string[] = Array.isArray(multi) ? multi : q?.correctAnswerId ? [q.correctAnswerId] : [];
+      const isMultiple = q?.type === "multiple" || (Array.isArray(multi) && multi.length > 1);
+      return { ...q, id: q?.id || `q${i + 1}`, text: q?.text ?? "", answers, correctIds, isMultiple };
+    }),
+  };
+}
+
+/** Inverse of `normalizeQuizContent`: emit the saved quiz payload. */
+function serializeQuizContent(value: { passingScore: number; questions: any[] }): any {
+  return {
+    passingScore: value.passingScore,
+    questions: value.questions.map((q) => {
+      const {
+        correctIds, isMultiple,
+        options: _opts, correctAnswerIds: _cai, correctAnswerId: _ca, type: _type,
+        ...rest
+      } = q;
+      return {
+        ...rest,
+        ...(isMultiple
+          ? { type: "multiple", correctAnswerIds: correctIds }
+          : { correctAnswerId: correctIds[0] || "" }),
+      };
+    }),
+  };
+}
+
+/** Structured question/answer builder for `quiz` lessons. */
+function QuizLessonFields({ content, onChange }: {
+  content: any;
+  onChange: (content: any) => void;
+}) {
+  const quiz = normalizeQuizContent(content);
+  const commit = (next: { passingScore: number; questions: any[] }) => onChange(serializeQuizContent(next));
+  const updateQuestion = (qi: number, patch: Record<string, any>) => {
+    commit({ ...quiz, questions: quiz.questions.map((q, i) => (i === qi ? { ...q, ...patch } : q)) });
+  };
+
+  const toggleCorrect = (q: any, qi: number, answerId: string, on: boolean) => {
+    if (!q.isMultiple) {
+      updateQuestion(qi, { correctIds: on ? [answerId] : [] });
+      return;
+    }
+    const next = on
+      ? Array.from(new Set([...q.correctIds, answerId]))
+      : q.correctIds.filter((id: string) => id !== answerId);
+    updateQuestion(qi, { correctIds: next });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <Label htmlFor="quiz-passing" className="text-xs">Passing score (%)</Label>
+        <Input
+          id="quiz-passing"
+          type="number"
+          min={0}
+          max={100}
+          className="w-28"
+          value={quiz.passingScore}
+          onChange={(e) => commit({ ...quiz, passingScore: Math.max(0, Math.min(100, Number(e.target.value) || 0)) })}
+          data-testid="input-quiz-passing-score"
+        />
+      </div>
+      {quiz.questions.map((q, qi) => (
+        <div key={q.id} className="rounded-md border p-3 space-y-2" data-testid={`quiz-question-${qi}`}>
+          <div className="flex items-center justify-between gap-2">
+            <Label className="text-xs text-muted-foreground">Question {qi + 1}</Label>
+            <Button
+              type="button" variant="ghost" size="sm" className="h-7 w-7 p-0 text-destructive"
+              onClick={() => commit({ ...quiz, questions: quiz.questions.filter((_, i) => i !== qi) })}
+              title="Delete question" aria-label={`Delete question ${qi + 1}`}
+            >
+              <Trash className="h-4 w-4" />
+            </Button>
+          </div>
+          <Input
+            value={q.text}
+            onChange={(e) => updateQuestion(qi, { text: e.target.value })}
+            placeholder="Question text"
+            data-testid={`input-quiz-question-${qi}`}
+          />
+          <div className="flex items-center gap-2">
+            <Switch
+              id={`quiz-multi-${qi}`}
+              checked={q.isMultiple}
+              onCheckedChange={(v) => updateQuestion(qi, {
+                isMultiple: v,
+                // Collapsing to single-answer keeps only the first correct choice.
+                correctIds: v ? q.correctIds : q.correctIds.slice(0, 1),
+              })}
+            />
+            <Label htmlFor={`quiz-multi-${qi}`} className="text-xs">Multiple correct answers</Label>
+          </div>
+          <div className="space-y-1.5">
+            {q.answers.map((a: any, ai: number) => (
+              <div key={a.id} className="flex items-center gap-2">
+                <Checkbox
+                  checked={q.correctIds.includes(a.id)}
+                  onCheckedChange={(on) => toggleCorrect(q, qi, a.id, on === true)}
+                  title="Correct answer"
+                  aria-label={`Mark answer ${ai + 1} correct`}
+                  data-testid={`checkbox-quiz-correct-${qi}-${ai}`}
+                />
+                <Input
+                  value={a.text}
+                  onChange={(e) => updateQuestion(qi, {
+                    answers: q.answers.map((x: any, j: number) => (j === ai ? { ...x, text: e.target.value } : x)),
+                  })}
+                  placeholder={`Answer ${ai + 1}`}
+                  data-testid={`input-quiz-answer-${qi}-${ai}`}
+                />
+                <Button
+                  type="button" variant="ghost" size="sm" className="h-7 w-7 p-0 text-destructive shrink-0"
+                  onClick={() => updateQuestion(qi, {
+                    answers: q.answers.filter((_: any, j: number) => j !== ai),
+                    correctIds: q.correctIds.filter((id: string) => id !== a.id),
+                  })}
+                  title="Delete answer" aria-label={`Delete answer ${ai + 1}`}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+          </div>
+          <Button
+            type="button" variant="outline" size="sm"
+            onClick={() => updateQuestion(qi, { answers: [...q.answers, { id: genId("a"), text: "" }] })}
+            data-testid={`button-add-answer-${qi}`}
+          >
+            <Plus className="h-4 w-4 mr-1" /> Answer
+          </Button>
+          {q.correctIds.length === 0 && (
+            <p className="text-xs text-amber-600 dark:text-amber-500">Mark at least one answer as correct.</p>
+          )}
+        </div>
+      ))}
+      <Button
+        type="button" variant="outline" size="sm"
+        onClick={() => commit({
+          ...quiz,
+          questions: [...quiz.questions, {
+            id: genId("q"), text: "", isMultiple: false, correctIds: [],
+            answers: [{ id: genId("a"), text: "" }, { id: genId("a"), text: "" }],
+          }],
+        })}
+        data-testid="button-add-question"
+      >
+        <Plus className="h-4 w-4 mr-1" /> Question
+      </Button>
+    </div>
+  );
+}
+
 function defaultContentFor(type: LessonType): any {
   switch (type) {
-    case "rich_text": return { html: "<p>Lesson content goes here.</p>" };
+    case "rich_text": return { html: "" };
     case "slides": return {
       slides: [
         {

--- a/client/src/components/admin/SlideEditor.tsx
+++ b/client/src/components/admin/SlideEditor.tsx
@@ -11,7 +11,7 @@
  * `pages/CourseDetail.tsx`; both consume the shared slide model in
  * `@shared/slides`, so the editor and player stay in lock-step.
  */
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -22,161 +22,18 @@ import {
 } from "@/components/ui/dropdown-menu";
 import {
   Plus, Trash, ChevronUp, ChevronDown, Image as ImageIcon, Video, Type, Heading,
-  Lightbulb, Upload, Bold, Italic, List, Link as LinkIcon, Mic, Loader2, Sparkles,
+  Lightbulb, Upload, Mic, Loader2, Sparkles,
 } from "lucide-react";
 import { ObjectUploader } from "@/components/ObjectUploader";
 import { useToast } from "@/hooks/use-toast";
 import {
+  RichTextField, MediaUrlInput, getUploadParameters, finalizeUploaded,
+  requestTts, TTS_VOICES, DEFAULT_VOICE,
+} from "@/components/admin/editor-fields";
+import {
   genId, blankSlide, normalizeSlides, courseMediaUrl,
   type Slide, type SlideBlock, type SlidesContent, type SlideNarrationMode,
 } from "@shared/slides";
-
-async function getUploadParameters() {
-  const res = await fetch("/api/objects/upload", { method: "POST", credentials: "include" });
-  const data = await res.json();
-  return { method: "PUT" as const, url: data.uploadURL };
-}
-
-/**
- * Resolve the raw URL from a completed Uppy upload, then normalize it to a
- * stable `/objects/...` path. The server finalizes course/lesson media with a
- * *private* ACL; learners read it through the course-aware media proxy
- * (`courseMediaUrl()` → `GET /api/courses/:id/media`). Falls back to the raw
- * URL if finalize fails (still better than nothing).
- */
-async function finalizeUploaded(result: any): Promise<string | undefined> {
-  const raw = result?.successful?.[0]?.uploadURL;
-  if (!raw) return undefined;
-  try {
-    const res = await fetch("/api/objects/finalize", {
-      method: "POST",
-      credentials: "include",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ url: raw }),
-    });
-    if (res.ok) {
-      const data = await res.json();
-      return data.url || raw;
-    }
-  } catch {
-    /* fall through to raw */
-  }
-  return raw;
-}
-
-/** Curated Azure neural voices offered in the narration picker. */
-const TTS_VOICES: { id: string; label: string }[] = [
-  { id: "en-US-JennyNeural", label: "Jenny (US, female)" },
-  { id: "en-US-AriaNeural", label: "Aria (US, female)" },
-  { id: "en-US-GuyNeural", label: "Guy (US, male)" },
-  { id: "en-US-DavisNeural", label: "Davis (US, male)" },
-  { id: "en-GB-SoniaNeural", label: "Sonia (UK, female)" },
-  { id: "en-GB-RyanNeural", label: "Ryan (UK, male)" },
-  { id: "en-AU-NatashaNeural", label: "Natasha (AU, female)" },
-];
-const DEFAULT_VOICE = TTS_VOICES[0].id;
-
-/** Request TTS narration for some text; returns the stored audio URL + voice. */
-async function requestTts(courseId: string, text: string, voice?: string): Promise<{ audioUrl: string; voice: string }> {
-  const res = await fetch(`/api/courses/${courseId}/narration/tts`, {
-    method: "POST",
-    credentials: "include",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ text, voice }),
-  });
-  const data = await res.json();
-  if (!res.ok) throw new Error(data.error || "Failed to generate narration");
-  return data;
-}
-
-/** contentEditable rich-text field with a minimal formatting toolbar. */
-function RichTextField({ value, onChange, placeholder }: {
-  value: string;
-  onChange: (html: string) => void;
-  placeholder?: string;
-}) {
-  const ref = useRef<HTMLDivElement>(null);
-
-  // Initialize once on mount; the caller remounts (via `key`) when switching
-  // blocks/slides, so we never fight React over the cursor position.
-  useEffect(() => {
-    if (ref.current && ref.current.innerHTML !== value) {
-      ref.current.innerHTML = value || "";
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const exec = (cmd: string, arg?: string) => {
-    ref.current?.focus();
-    // execCommand is deprecated but universally supported; fine for an
-    // internal authoring tool. Output is sanitized at render time.
-    document.execCommand(cmd, false, arg);
-    if (ref.current) onChange(ref.current.innerHTML);
-  };
-
-  return (
-    <div className="rounded-md border">
-      <div className="flex items-center gap-1 border-b bg-muted/40 px-1 py-1" role="toolbar" aria-label="Text formatting">
-        <Button type="button" variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => exec("bold")} title="Bold" aria-label="Bold">
-          <Bold className="h-3.5 w-3.5" />
-        </Button>
-        <Button type="button" variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => exec("italic")} title="Italic" aria-label="Italic">
-          <Italic className="h-3.5 w-3.5" />
-        </Button>
-        <Button type="button" variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => exec("insertUnorderedList")} title="Bulleted list" aria-label="Bulleted list">
-          <List className="h-3.5 w-3.5" />
-        </Button>
-        <Button
-          type="button" variant="ghost" size="sm" className="h-7 w-7 p-0" title="Link" aria-label="Insert link"
-          onClick={() => {
-            const url = window.prompt("Link URL");
-            if (url) exec("createLink", url);
-          }}
-        >
-          <LinkIcon className="h-3.5 w-3.5" />
-        </Button>
-      </div>
-      <div
-        ref={ref}
-        contentEditable
-        role="textbox"
-        aria-multiline="true"
-        aria-label={placeholder || "Rich text"}
-        suppressContentEditableWarning
-        onInput={(e) => onChange((e.target as HTMLDivElement).innerHTML)}
-        data-placeholder={placeholder || "Type here…"}
-        className="prose prose-sm dark:prose-invert max-w-none min-h-[80px] px-3 py-2 text-sm focus:outline-none empty:before:text-muted-foreground empty:before:content-[attr(data-placeholder)]"
-      />
-    </div>
-  );
-}
-
-function MediaUrlInput({ label, url, onChange, accept, fileTypes }: {
-  label: string;
-  url: string;
-  onChange: (url: string) => void;
-  accept?: string;
-  fileTypes: string[];
-}) {
-  return (
-    <div className="flex items-end gap-2">
-      <div className="flex-1">
-        <Label className="text-xs">{label}</Label>
-        <Input value={url} onChange={(e) => onChange(e.target.value)} placeholder="https://… or upload" />
-      </div>
-      <ObjectUploader
-        maxNumberOfFiles={1}
-        maxFileSize={524288000 /* 500MB for video/audio */}
-        allowedFileTypes={fileTypes}
-        onGetUploadParameters={getUploadParameters}
-        onComplete={async (r) => { const u = await finalizeUploaded(r); if (u) onChange(u); }}
-        buttonVariant="outline"
-      >
-        <Upload className="h-4 w-4" aria-label="Upload file" />
-      </ObjectUploader>
-    </div>
-  );
-}
 
 function BlockEditor({ block, courseId, onChange }: { block: SlideBlock; courseId: string; onChange: (b: SlideBlock) => void }) {
   switch (block.type) {

--- a/client/src/components/admin/editor-fields.tsx
+++ b/client/src/components/admin/editor-fields.tsx
@@ -1,0 +1,161 @@
+/**
+ * Shared authoring fields for course content editors.
+ *
+ * Extracted from SlideEditor so the lesson editor dialog (rich text, video,
+ * audio lessons) and the slide editor use the same rich-text field,
+ * upload-backed media inputs, and TTS plumbing.
+ */
+import { useEffect, useRef } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Bold, Italic, List, Link as LinkIcon, Upload } from "lucide-react";
+import { ObjectUploader } from "@/components/ObjectUploader";
+
+export async function getUploadParameters() {
+  const res = await fetch("/api/objects/upload", { method: "POST", credentials: "include" });
+  const data = await res.json();
+  return { method: "PUT" as const, url: data.uploadURL };
+}
+
+/**
+ * Resolve the raw URL from a completed Uppy upload, then normalize it to a
+ * stable `/objects/...` path. The server finalizes course/lesson media with a
+ * *private* ACL; learners read it through the course-aware media proxy
+ * (`courseMediaUrl()` → `GET /api/courses/:id/media`). Falls back to the raw
+ * URL if finalize fails (still better than nothing).
+ */
+export async function finalizeUploaded(result: any): Promise<string | undefined> {
+  const raw = result?.successful?.[0]?.uploadURL;
+  if (!raw) return undefined;
+  try {
+    const res = await fetch("/api/objects/finalize", {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url: raw }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      return data.url || raw;
+    }
+  } catch {
+    /* fall through to raw */
+  }
+  return raw;
+}
+
+/** Curated Azure neural voices offered in the narration picker. */
+export const TTS_VOICES: { id: string; label: string }[] = [
+  { id: "en-US-JennyNeural", label: "Jenny (US, female)" },
+  { id: "en-US-AriaNeural", label: "Aria (US, female)" },
+  { id: "en-US-GuyNeural", label: "Guy (US, male)" },
+  { id: "en-US-DavisNeural", label: "Davis (US, male)" },
+  { id: "en-GB-SoniaNeural", label: "Sonia (UK, female)" },
+  { id: "en-GB-RyanNeural", label: "Ryan (UK, male)" },
+  { id: "en-AU-NatashaNeural", label: "Natasha (AU, female)" },
+];
+export const DEFAULT_VOICE = TTS_VOICES[0].id;
+
+/** Request TTS narration for some text; returns the stored audio URL + voice. */
+export async function requestTts(courseId: string, text: string, voice?: string): Promise<{ audioUrl: string; voice: string }> {
+  const res = await fetch(`/api/courses/${courseId}/narration/tts`, {
+    method: "POST",
+    credentials: "include",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ text, voice }),
+  });
+  const data = await res.json();
+  if (!res.ok) throw new Error(data.error || "Failed to generate narration");
+  return data;
+}
+
+/** contentEditable rich-text field with a minimal formatting toolbar. */
+export function RichTextField({ value, onChange, placeholder, minHeight }: {
+  value: string;
+  onChange: (html: string) => void;
+  placeholder?: string;
+  minHeight?: number;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Initialize once on mount; the caller remounts (via `key`) when switching
+  // blocks/slides, so we never fight React over the cursor position.
+  useEffect(() => {
+    if (ref.current && ref.current.innerHTML !== value) {
+      ref.current.innerHTML = value || "";
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const exec = (cmd: string, arg?: string) => {
+    ref.current?.focus();
+    // execCommand is deprecated but universally supported; fine for an
+    // internal authoring tool. Output is sanitized at render time.
+    document.execCommand(cmd, false, arg);
+    if (ref.current) onChange(ref.current.innerHTML);
+  };
+
+  return (
+    <div className="rounded-md border">
+      <div className="flex items-center gap-1 border-b bg-muted/40 px-1 py-1" role="toolbar" aria-label="Text formatting">
+        <Button type="button" variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => exec("bold")} title="Bold" aria-label="Bold">
+          <Bold className="h-3.5 w-3.5" />
+        </Button>
+        <Button type="button" variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => exec("italic")} title="Italic" aria-label="Italic">
+          <Italic className="h-3.5 w-3.5" />
+        </Button>
+        <Button type="button" variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => exec("insertUnorderedList")} title="Bulleted list" aria-label="Bulleted list">
+          <List className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button" variant="ghost" size="sm" className="h-7 w-7 p-0" title="Link" aria-label="Insert link"
+          onClick={() => {
+            const url = window.prompt("Link URL");
+            if (url) exec("createLink", url);
+          }}
+        >
+          <LinkIcon className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+      <div
+        ref={ref}
+        contentEditable
+        role="textbox"
+        aria-multiline="true"
+        aria-label={placeholder || "Rich text"}
+        suppressContentEditableWarning
+        onInput={(e) => onChange((e.target as HTMLDivElement).innerHTML)}
+        data-placeholder={placeholder || "Type here…"}
+        style={minHeight ? { minHeight } : undefined}
+        className="prose prose-sm dark:prose-invert max-w-none min-h-[80px] px-3 py-2 text-sm focus:outline-none empty:before:text-muted-foreground empty:before:content-[attr(data-placeholder)]"
+      />
+    </div>
+  );
+}
+
+export function MediaUrlInput({ label, url, onChange, fileTypes }: {
+  label: string;
+  url: string;
+  onChange: (url: string) => void;
+  fileTypes: string[];
+}) {
+  return (
+    <div className="flex items-end gap-2">
+      <div className="flex-1">
+        <Label className="text-xs">{label}</Label>
+        <Input value={url} onChange={(e) => onChange(e.target.value)} placeholder="https://… or upload" />
+      </div>
+      <ObjectUploader
+        maxNumberOfFiles={1}
+        maxFileSize={524288000 /* 500MB for video/audio */}
+        allowedFileTypes={fileTypes}
+        onGetUploadParameters={getUploadParameters}
+        onComplete={async (r) => { const u = await finalizeUploaded(r); if (u) onChange(u); }}
+        buttonVariant="outline"
+      >
+        <Upload className="h-4 w-4" aria-label="Upload file" />
+      </ObjectUploader>
+    </div>
+  );
+}

--- a/client/src/components/admin/editor-fields.tsx
+++ b/client/src/components/admin/editor-fields.tsx
@@ -79,14 +79,16 @@ export function RichTextField({ value, onChange, placeholder, minHeight }: {
 }) {
   const ref = useRef<HTMLDivElement>(null);
 
-  // Initialize once on mount; the caller remounts (via `key`) when switching
-  // blocks/slides, so we never fight React over the cursor position.
+  // Sync external `value` changes (e.g. edits made in the Advanced raw-JSON
+  // textarea) into the DOM — but never while the field is focused: during
+  // typing the DOM is the source of truth, and rewriting innerHTML would
+  // clobber the cursor and any keystrokes not yet flushed through React.
   useEffect(() => {
-    if (ref.current && ref.current.innerHTML !== value) {
-      ref.current.innerHTML = value || "";
+    const el = ref.current;
+    if (el && document.activeElement !== el && el.innerHTML !== value) {
+      el.innerHTML = value || "";
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [value]);
 
   const exec = (cmd: string, arg?: string) => {
     ref.current?.focus();

--- a/client/src/pages/CourseDetail.tsx
+++ b/client/src/pages/CourseDetail.tsx
@@ -564,14 +564,17 @@ function CoursePlayer({ course, lesson, currentIndex, total, progress, onPrev, o
         );
       }
       case "video": {
-        const isEmbed = c.provider === 'youtube' || c.provider === 'vimeo' ||
-          (c.videoUrl && (c.videoUrl.includes('youtube.com') || c.videoUrl.includes('youtu.be') || c.videoUrl.includes('vimeo.com')));
+        // Managed uploads live at /objects/... (private) and must be served
+        // via the course media proxy; external links must be safe http(s).
+        const isManaged = /^\/objects\/(?:uploads|narration|slides)\//.test(c.videoUrl || "");
+        const isEmbed = !isManaged && (c.provider === 'youtube' || c.provider === 'vimeo' ||
+          (c.videoUrl && (c.videoUrl.includes('youtube.com') || c.videoUrl.includes('youtu.be') || c.videoUrl.includes('vimeo.com'))));
         return (
           <div data-testid="content-video" className="space-y-3">
             {c.description && (
               <p className="text-sm text-muted-foreground">{c.description}</p>
             )}
-            {!c.videoUrl || !isSafeHttpUrl(c.videoUrl) ? (
+            {!c.videoUrl || (!isManaged && !isSafeHttpUrl(c.videoUrl)) ? (
               <p className="text-sm text-muted-foreground">No video URL configured.</p>
             ) : isEmbed ? (
               <div className="relative w-full rounded-md overflow-hidden" style={{ paddingBottom: '56.25%' }}>
@@ -585,7 +588,7 @@ function CoursePlayer({ course, lesson, currentIndex, total, progress, onPrev, o
                 />
               </div>
             ) : (
-              <video src={c.videoUrl} controls className="w-full rounded-md" />
+              <video src={courseMediaUrl(course.id, c.videoUrl)} controls className="w-full rounded-md" />
             )}
           </div>
         );
@@ -597,9 +600,15 @@ function CoursePlayer({ course, lesson, currentIndex, total, progress, onPrev, o
               <p className="text-sm text-muted-foreground">{c.description}</p>
             )}
             {c.audioUrl ? (
-              <audio src={c.audioUrl} controls className="w-full" />
+              <audio src={courseMediaUrl(course.id, c.audioUrl)} controls className="w-full" />
             ) : (
               <p className="text-sm text-muted-foreground">No audio URL configured.</p>
+            )}
+            {c.transcript && (
+              <details>
+                <summary className="text-xs text-muted-foreground cursor-pointer">Transcript</summary>
+                <p className="text-sm mt-1 whitespace-pre-wrap">{c.transcript}</p>
+              </details>
             )}
           </div>
         );

--- a/client/src/pages/CourseDetail.tsx
+++ b/client/src/pages/CourseDetail.tsx
@@ -593,13 +593,17 @@ function CoursePlayer({ course, lesson, currentIndex, total, progress, onPrev, o
           </div>
         );
       }
-      case "audio":
+      case "audio": {
+        // Same gating as video: managed uploads go through the media proxy,
+        // anything else must be a safe http(s) URL (no data:/javascript:).
+        const isManagedAudio = /^\/objects\/(?:uploads|narration|slides)\//.test(c.audioUrl || "");
+        const playableAudio = c.audioUrl && (isManagedAudio || isSafeHttpUrl(c.audioUrl));
         return (
           <div data-testid="content-audio" className="space-y-3">
             {c.description && (
               <p className="text-sm text-muted-foreground">{c.description}</p>
             )}
-            {c.audioUrl ? (
+            {playableAudio ? (
               <audio src={courseMediaUrl(course.id, c.audioUrl)} controls className="w-full" />
             ) : (
               <p className="text-sm text-muted-foreground">No audio URL configured.</p>
@@ -612,6 +616,7 @@ function CoursePlayer({ course, lesson, currentIndex, total, progress, onPrev, o
             )}
           </div>
         );
+      }
       case "quiz": {
         const questions: any[] = c.questions || [];
         if (submittedScore !== null) {


### PR DESCRIPTION
The lesson editor dialog only gave slides lessons a structured editor;
rich text, video, audio, quiz, attestation, and SCORM lessons all dropped
into a raw JSON textarea. Authors now get:

- Rich text: the formatting-toolbar editor (shared with the slide editor)
- Video: URL input with direct upload, provider picker, description, preview
- Audio: URL input with direct upload, preview, description, and
  generate-from-script TTS with voice picker
- Quiz: question/answer builder with passing score, single/multiple
  correct answers, and add/remove controls
- Attestation: statement text plus typed-signature switch
- SCORM: read-only package summary fed by the existing zip upload
- Raw JSON remains available under a collapsed Advanced section

Shared authoring fields (RichTextField, MediaUrlInput, upload finalize,
TTS plumbing) moved out of SlideEditor into editor-fields.tsx.

Also fixes the learner player for uploaded video/audio lessons: managed
/objects/... media is private and must stream through the course media
proxy (as slide blocks already did), so videoUrl/audioUrl are now wrapped
in courseMediaUrl and managed paths pass the URL safety check. Audio
lessons additionally render the script as a transcript when present.

https://claude.ai/code/session_01QnHn1nK6L2hHBtVvYtKGnA